### PR TITLE
Removed "tighter" and "looser" line-height tokens to simplify options

### DIFF
--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -253,20 +253,14 @@ export const lineHeights = {
   none: {
     value: '1',
   },
-  tighter: {
-    value: '1em + 0.125rem',
-  },
   tight: {
-    value: '1em + 0.25rem',
+    value: '1em + 0.25rem', // 4
   },
   default: {
-    value: '1em + 0.5rem',
+    value: '1em + 0.5rem', // 8
   },
   loose: {
-    value: '1em + 0.75rem',
-  },
-  looser: {
-    value: '1em + 0.875rem',
+    value: '1em + 0.75rem', // 12
   },
 };
 


### PR DESCRIPTION
This makes for fewer options, and the majority of the remaining options better align with our 4px vertical grid. I was also able to implement this in a clearer way in Figma, so that should be easier going forward too.