### PR TITLE
updated splitProps function to retain classNames

### DIFF
--- a/src/utils/splitProps.ts
+++ b/src/utils/splitProps.ts
@@ -1,11 +1,18 @@
 import { splitCssProps } from '@styled-system/jsx';
-import { css } from '@styled-system/css';
+import { css, cx } from '@styled-system/css';
 
 export const splitProps = (
-  props: Record<string, any>
+  props: Record<string, any>,
 ): [string, Record<string, any>] => {
   const [cssProps, otherProps] = splitCssProps(props);
   const { css: cssProp, ...styleProps } = cssProps;
-  const className: string  = css(cssProp, styleProps);
-  return [className, otherProps];
-}
+
+  const generatedClassName: string = css(cssProp, styleProps);
+  const existingClassName = otherProps.className || '';
+
+  const mergedClassName = cx(existingClassName, generatedClassName);
+
+  const { className, ...remainingProps } = otherProps;
+
+  return [mergedClassName, remainingProps];
+};


### PR DESCRIPTION
solution for className overwrite stuff instead of using wombo combo cx + recipe import stuff