### PR TITLE
refactor!: global styles scoping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ storybook-static
 .project-structure.md
 .session-summary.md
 .pair-programming-session.md
+/.tmp

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,6 +12,7 @@ const preview: Preview = {
         dark: 'dark',
       },
       defaultTheme: 'light',
+      parentSelector: 'body',
     }),
   ],
   initialGlobals: {},

--- a/.storybook/story-docs-style.css
+++ b/.storybook/story-docs-style.css
@@ -1,8 +1,25 @@
-.sbdocs-content {
-  padding-inline: var(--cetec-sizes-48);
+.sb-show-main,
+.docs-story {
+  background: var(--cetec-colors-surface);
 }
 
-.sb-docs {
+.sbdocs-content {
+  padding: var(--cetec-sizes-48);
+}
+
+.sbdocs {
+  font-family: var(--cetec-fonts-body);
+  font-variation-settings: var(--cetec-font-variant-body);
+  background: var(--cetec-colors-surface);
+  color: var(--cetec-colors-text-subtlest);
+  font-weight: var(--cetec-font-weights-normal);
+
+  &.sbdocs-wrapper {
+    padding: 0;
+    gap: 0;
+    justify-content: start;
+  }
+
   h1,
   h2,
   h3,
@@ -29,9 +46,13 @@
 
   h1 {
     font-size: var(--cetec-font-sizes-40);
+
+    &.sbdocs-title {
+      font-size: var(--cetec-font-sizes-64);
+    }
   }
 
-  h2 {
+  h2:not(#stories) {
     font-size: var(--cetec-font-sizes-32);
   }
 
@@ -111,5 +132,9 @@
       padding: var(--cetec-sizes-12);
       margin: 0;
     }
+  }
+
+  #additional-variations {
+    margin-top: var(--cetec-sizes-48);
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
       "default": "./dist/preset.js"
     },
     "./sprite.svg": "./dist/sprite.svg",
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./reset.css": "./dist/reset.css"
   },
   "repository": {
     "type": "git",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -425,10 +425,10 @@ const AppContent: React.FC = () => {
                 <Pre>
                   {`<Text>
     ...
-  <Text as="span" italic>winged fourth</Text>
-  <Text as="span" bold>replenish</Text>
-  <Text as="span" underline>whales</Text>
-</Text>`}
+        <Text as="span" italic>winged fourth</Text>
+        <Text as="span" bold>replenish</Text>
+        <Text as="span" underline>whales</Text>
+      </Text>`}
                 </Pre>
                 <Text family="mono">
                   Signs night have sixth hath that likeness us fill you're
@@ -817,14 +817,14 @@ const AppContent: React.FC = () => {
             <VStack gap="10" alignItems="flex-start">
               <Heading level="h3">Flat</Heading>
               <HStack gap="40" alignItems="flex-start">
-                <Card variant="flat">
-                  <Box className={css({ p: '16' })}>Default</Box>
+                <Card variant="flat" p="16">
+                  Default
                 </Card>
-                <Card variant="flat" grabbed>
-                  <Box className={css({ p: '16' })}>Grabbed</Box>
+                <Card variant="flat" p="16" grabbed>
+                  Grabbed
                 </Card>
-                <Card variant="flat" disabled>
-                  <Box className={css({ p: '16' })}>Disabled</Box>
+                <Card variant="flat" p="16" disabled>
+                  Disabled
                 </Card>
               </HStack>
             </VStack>

--- a/src/recipes/badge.ts
+++ b/src/recipes/badge.ts
@@ -19,7 +19,7 @@ export const badgeRecipe = defineSlotRecipe({
       borderRadius: '999',
       fontWeight: 'medium',
       fontFamily: 'body',
-      lineHeight: '1',
+      lineHeight: 'none',
       whiteSpace: 'nowrap',
       userSelect: 'none',
       zIndex: '1',

--- a/src/recipes/badge.ts
+++ b/src/recipes/badge.ts
@@ -1,4 +1,5 @@
 import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 export const badgeRecipe = defineSlotRecipe({
   className: 'badge',
@@ -6,6 +7,7 @@ export const badgeRecipe = defineSlotRecipe({
   slots: ['root', 'indicator'],
   base: {
     root: {
+      ...globalBaseStyles,
       display: 'inline-flex',
       position: 'relative',
       verticalAlign: 'middle',

--- a/src/recipes/box.ts
+++ b/src/recipes/box.ts
@@ -1,16 +1,16 @@
 import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const boxBase = {
+  ...globalBaseStyles,
 };
 
-const boxVariants = {
-};
+const boxVariants = {};
 
 export const boxRecipe = defineRecipe({
   className: 'box',
   jsx: ['Box'],
   base: boxBase,
   variants: boxVariants,
-  defaultVariants: {
-  },
+  defaultVariants: {},
 });

--- a/src/recipes/breadcrumbs.ts
+++ b/src/recipes/breadcrumbs.ts
@@ -1,6 +1,8 @@
 import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const BreadcrumbsBase = {
+  ...globalBaseStyles,
   display: 'flex',
   alignItems: 'center',
   '& li': {

--- a/src/recipes/breadcrumbs.ts
+++ b/src/recipes/breadcrumbs.ts
@@ -1,31 +1,29 @@
 import { defineRecipe } from '@pandacss/dev';
 import { globalBaseStyles } from '~/styles/utilities';
 
-const BreadcrumbsBase = {
-  ...globalBaseStyles,
-  display: 'flex',
-  alignItems: 'center',
-  '& li': {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  '& a': {
-    color: { base: 'slate.60', _dark: 'slate.30' },
-    _focusVisible: {
-      color: 'blue.50',
-    },
-  },
-  '& p': {
-    color: { base: 'slate.90', _dark: 'slate.0' },
-  },
-  '& span': {
-    mx: '6',
-    color: { base: 'slate.20', _dark: 'slate.50' },
-  },
-};
-
 export const breadcrumbsRecipe = defineRecipe({
   className: 'breadcrumbs',
   jsx: ['Breadcrumbs'],
-  base: BreadcrumbsBase,
+  base: {
+    ...globalBaseStyles,
+    display: 'flex',
+    alignItems: 'center',
+    '& li': {
+      display: 'flex',
+      alignItems: 'center',
+    },
+    '& a': {
+      color: { base: 'slate.60', _dark: 'slate.30' },
+      _focusVisible: {
+        color: 'blue.50',
+      },
+    },
+    '& p': {
+      color: { base: 'slate.90', _dark: 'slate.0' },
+    },
+    '& span': {
+      mx: '6',
+      color: { base: 'slate.20', _dark: 'slate.50' },
+    },
+  },
 });

--- a/src/recipes/button.ts
+++ b/src/recipes/button.ts
@@ -1,13 +1,11 @@
-import { defineSlotRecipe, defineStyles } from '@pandacss/dev';
+import { defineSlotRecipe } from '@pandacss/dev';
 import { globalBaseStyles } from '~/styles/utilities';
 
-const buttonBaseStyles = defineStyles({
+const buttonBaseStyles = {
   container: {
     ...globalBaseStyles,
     position: 'relative',
-    // appearance: 'none',
-    appearance: 'button',
-    '-webkit-appearance': 'button',
+    appearance: 'none',
     display: 'flex',
     alignItems: 'center',
     gap: '4',
@@ -19,7 +17,6 @@ const buttonBaseStyles = defineStyles({
     transitionTimingFunction: 'default',
     userSelect: 'none',
     verticalAlign: 'middle',
-    // fontFamily: 'body',
     fontSize: '16',
     fontWeight: 'medium',
     lineHeight: 'default',
@@ -52,7 +49,7 @@ const buttonBaseStyles = defineStyles({
     transitionProperty: 'fill',
     transitionTimingFunction: 'default',
   },
-});
+};
 
 const buttonVariants = {
   variant: {

--- a/src/recipes/button.ts
+++ b/src/recipes/button.ts
@@ -1,9 +1,13 @@
-import { defineSlotRecipe } from '@pandacss/dev';
+import { defineSlotRecipe, defineStyles } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
-const buttonBaseStyles = {
+const buttonBaseStyles = defineStyles({
   container: {
+    ...globalBaseStyles,
     position: 'relative',
-    appearance: 'none',
+    // appearance: 'none',
+    appearance: 'button',
+    '-webkit-appearance': 'button',
     display: 'flex',
     alignItems: 'center',
     gap: '4',
@@ -15,7 +19,7 @@ const buttonBaseStyles = {
     transitionTimingFunction: 'default',
     userSelect: 'none',
     verticalAlign: 'middle',
-    fontFamily: 'body',
+    // fontFamily: 'body',
     fontSize: '16',
     fontWeight: 'medium',
     lineHeight: 'default',
@@ -48,7 +52,7 @@ const buttonBaseStyles = {
     transitionProperty: 'fill',
     transitionTimingFunction: 'default',
   },
-};
+});
 
 const buttonVariants = {
   variant: {

--- a/src/recipes/checkboxInput.ts
+++ b/src/recipes/checkboxInput.ts
@@ -1,15 +1,15 @@
-import { defineRecipe } from "@pandacss/dev";
+import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const checkboxInputBase = {
-    display: 'flex',
-    gap: '4'
-}
+  ...globalBaseStyles,
+  display: 'flex',
+  gap: '4',
+};
 
 export const checkboxInputRecipe = defineRecipe({
-    className: 'checkbox-input',
-    jsx: ["CheckboxInput"],
-    base: checkboxInputBase,
-    variants: {
-
-    }
-})
+  className: 'checkbox-input',
+  jsx: ['CheckboxInput'],
+  base: checkboxInputBase,
+  variants: {},
+});

--- a/src/recipes/chip.ts
+++ b/src/recipes/chip.ts
@@ -1,7 +1,9 @@
 import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const chipBase = {
   container: {
+    ...globalBaseStyles,
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',

--- a/src/recipes/code.ts
+++ b/src/recipes/code.ts
@@ -1,30 +1,33 @@
 import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const codeBase = {
+  ...globalBaseStyles,
   bg: 'slate.80',
-  position: "relative",
-  overflow: "auto",
-  p: "4",
-  whiteSpace: "pre",
-  fontSize: "14",
+  position: 'relative',
+  overflow: 'auto',
+  p: '4',
+  whiteSpace: 'pre',
+  fontSize: '14',
 };
 
 const preBase = {
-  borderRadius: "8",
-  overflow: "hidden",
-  borderWidth: "0",
-  borderColor: "slate.60",
-  bg: "slate.80",
-  color: "slate.5",
-  px: "16",
-  py: "8",
-  my: "8",
-  whiteSpace: "pre",
+  ...globalBaseStyles,
+  borderRadius: '8',
+  overflow: 'hidden',
+  borderWidth: '0',
+  borderColor: 'slate.60',
+  bg: 'slate.80',
+  color: 'slate.5',
+  px: '16',
+  py: '8',
+  my: '8',
+  whiteSpace: 'pre',
 };
 
 export const codeRecipe = defineRecipe({
   className: 'code',
-  jsx:['Code'],
+  jsx: ['Code'],
   base: codeBase,
 });
 
@@ -33,5 +36,3 @@ export const preRecipe = defineRecipe({
   jsx: ['Pre'],
   base: preBase,
 });
-
-

--- a/src/recipes/formField.ts
+++ b/src/recipes/formField.ts
@@ -1,7 +1,9 @@
 import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const formFieldBase = {
   formFieldContainer: {
+    ...globalBaseStyles,
     _disabled: {
       opacity: '0.4',
       pointerEvents: 'none',

--- a/src/recipes/menu.ts
+++ b/src/recipes/menu.ts
@@ -1,7 +1,9 @@
 import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const menuBase = {
   wrapper: {
+    ...globalBaseStyles,
     position: { base: 'fixed', md: 'relative' },
     left: '0',
     bottom: '0',
@@ -31,6 +33,7 @@ const menuBase = {
   },
 
   menuItem: {
+    ...globalBaseStyles,
     display: 'flex',
     gap: '4',
     px: { base: '20', md: '12' },

--- a/src/recipes/modal.ts
+++ b/src/recipes/modal.ts
@@ -1,4 +1,5 @@
 import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const modalBase = {
   overlay: {
@@ -15,6 +16,7 @@ const modalBase = {
     },
   },
   container: {
+    ...globalBaseStyles,
     position: 'fixed',
     top: '50%',
     left: '50%',

--- a/src/recipes/radio.ts
+++ b/src/recipes/radio.ts
@@ -1,71 +1,73 @@
-import { defineSlotRecipe } from "@pandacss/dev";
+import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 export const radioRecipe = defineSlotRecipe({
-    className: "radio",
-    jsx: ['Radio'],
-    slots: ["container", "input", "indicator"],
-    base: {
-        container: {
-            position: "relative",
-            display: "inline-grid",
-            gridTemplateColumns: "auto 1fr",  
-            gap: 4,
-            alignItems: "start",
-            cursor: "pointer",
-            userSelect: "none",
-        },
-        input: {
-            position: "absolute",
-            opacity: 0          ,
-            width: "full",
-            height: "full",
-            margin: "0",
-            padding: "0",
-            zIndex: 1,
-            cursor: "inherit",
-            "& ~ [name='radio']": {
-              display: "inline-grid",
-            },
-            _checked: {
-              "& ~ [name='radio-checked']": {
-                display: "inline-grid",
-                fill: { base: "slate.90", _dark: "slate.0" },
-              },
-              "& ~ [name='radio']": {
-                display: "none",
-              },
-            },
-            _disabled: {
-              "& ~ svg": {
-                opacity: 0.4,
-                pointerEvents: 'none',
-                cursor: 'none',
-              },
-              display: "inline-grid",
-            },
-            _error: {
-              display: "inline-grid",
-              "& ~ svg": {
-                fill: "red.50",
-              }
-            },
-            _focusVisible: {
-              "& ~ [name='radio-focus']": {
-                display: 'inline-grid',
-                position: 'absolute',
-                fill: { base: 'slate.90', _dark: 'slate.1' },
-              },
-            },
-        },
-        indicator: {
-            placeContent: "center",
-            display: 'none',
-            width: 24,
-            height: 24,
-            "&:is([name='radio'])": {
-              display: "inline-grid",
-              fill: "slate.20",
-            },
-        },
+  className: 'radio',
+  jsx: ['Radio'],
+  slots: ['container', 'input', 'indicator'],
+  base: {
+    container: {
+      ...globalBaseStyles,
+      position: 'relative',
+      display: 'inline-grid',
+      gridTemplateColumns: 'auto 1fr',
+      gap: 4,
+      alignItems: 'start',
+      cursor: 'pointer',
+      userSelect: 'none',
     },
-})
+    input: {
+      position: 'absolute',
+      opacity: 0,
+      width: 'full',
+      height: 'full',
+      margin: '0',
+      padding: '0',
+      zIndex: 1,
+      cursor: 'inherit',
+      "& ~ [name='radio']": {
+        display: 'inline-grid',
+      },
+      _checked: {
+        "& ~ [name='radio-checked']": {
+          display: 'inline-grid',
+          fill: { base: 'slate.90', _dark: 'slate.0' },
+        },
+        "& ~ [name='radio']": {
+          display: 'none',
+        },
+      },
+      _disabled: {
+        '& ~ svg': {
+          opacity: 0.4,
+          pointerEvents: 'none',
+          cursor: 'none',
+        },
+        display: 'inline-grid',
+      },
+      _error: {
+        display: 'inline-grid',
+        '& ~ svg': {
+          fill: 'red.50',
+        },
+      },
+      _focusVisible: {
+        "& ~ [name='radio-focus']": {
+          display: 'inline-grid',
+          position: 'absolute',
+          fill: { base: 'slate.90', _dark: 'slate.1' },
+        },
+      },
+    },
+    indicator: {
+      placeContent: 'center',
+      display: 'none',
+      width: 24,
+      height: 24,
+      "&:is([name='radio'])": {
+        display: 'inline-grid',
+        fill: 'slate.20',
+      },
+    },
+  },
+});

--- a/src/recipes/radioinput.ts
+++ b/src/recipes/radioinput.ts
@@ -1,15 +1,15 @@
-import { defineRecipe } from "@pandacss/dev";
+import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const radioInputBase = {
-    display: 'flex',
-    gap: '4'
-}
+  ...globalBaseStyles,
+  display: 'flex',
+  gap: '4',
+};
 
 export const radioInputRecipe = defineRecipe({
-    className: 'radio-input',
-    jsx: ["RadioInput"],
-    base: radioInputBase,
-    variants: {
-
-    }
-})
+  className: 'radio-input',
+  jsx: ['RadioInput'],
+  base: radioInputBase,
+  variants: {},
+});

--- a/src/recipes/tag.ts
+++ b/src/recipes/tag.ts
@@ -1,6 +1,8 @@
 import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const tagBase = {
+  ...globalBaseStyles,
   display: 'flex',
   py: '0',
   borderRadius: '2',

--- a/src/recipes/tag.ts
+++ b/src/recipes/tag.ts
@@ -10,7 +10,7 @@ const tagBase = {
   //   h: '20',
   px: '4',
   fontSize: '14',
-  fontWeight: '500',
+  fontWeight: 'medium',
   //   lineHeight: 'none',
 };
 const tagVariant = {
@@ -52,7 +52,7 @@ const tagVariant = {
   hasIcon: {
     true: {},
     false: {
-      px: 4,
+      px: '4',
     },
   },
 };

--- a/src/recipes/text.ts
+++ b/src/recipes/text.ts
@@ -6,12 +6,13 @@ import {
 import { fontVariants } from '../styles/utilities';
 
 const textBase = {
-  margin: '0',
-  lineHeight: 'default',
-  fontWeight: 'normal',
-  fontSize: '16',
+  fontFamily: 'body',
   fontVariationSettings: fontVariants.body,
-  color: { base: 'slate.60', _dark: 'slate.30' },
+  fontWeight: 'normal',
+  lineHeight: 'default',
+  color: 'text.subtlest',
+  margin: '0',
+  fontSize: '16',
   maxWidth: 'prose',
 };
 
@@ -38,7 +39,10 @@ const fontWeights = (Object.keys(fontWeightTokens) as FontWeightKey[]).reduce(
 const textVariants = {
   family: {
     heading: { fontFamily: 'heading' },
-    body: { fontFamily: 'body' },
+    body: {
+      fontFamily: 'body',
+      // fontVariationSettings: fontVariants.body,
+    },
     mono: {
       fontFamily: 'mono',
       fontVariationSettings: fontVariants.mono,
@@ -84,7 +88,7 @@ const textVariants = {
 const headingBase = {
   fontFamily: 'heading',
   fontWeight: 'black',
-  color: { base: 'slate.90', _dark: 'slate.5' },
+  color: 'text',
   lineHeight: 'default',
 };
 

--- a/src/recipes/textarea.ts
+++ b/src/recipes/textarea.ts
@@ -1,6 +1,9 @@
 import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const textareaBase = {
+  ...globalBaseStyles,
+  fontSize: '100%',
   position: 'relative',
   width: 'full',
   color: { base: 'slate.90', _dark: 'slate.0' },

--- a/src/recipes/textarea.ts
+++ b/src/recipes/textarea.ts
@@ -3,7 +3,7 @@ import { globalBaseStyles } from '~/styles/utilities';
 
 const textareaBase = {
   ...globalBaseStyles,
-  fontSize: '100%',
+  fontSize: '[100%]',
   position: 'relative',
   width: 'full',
   color: { base: 'slate.90', _dark: 'slate.0' },

--- a/src/recipes/textinput.ts
+++ b/src/recipes/textinput.ts
@@ -1,4 +1,5 @@
 import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const textInputVariants = {
   size: {
@@ -31,6 +32,10 @@ const textInputVariants = {
 };
 
 const textInputBase = {
+  ...globalBaseStyles,
+  fontSize: '100%',
+  appearance: 'textfield',
+  '-webkit-appearance': 'textfield',
   position: 'relative',
   width: 'full',
   borderWidth: '1',
@@ -38,7 +43,7 @@ const textInputBase = {
   borderStyle: 'solid',
   borderRadius: '4',
   lineHeight: 'default',
-  fontFamily: 'body',
+  // fontFamily: 'body',
   outlineWidth: '1',
   outlineStyle: 'solid',
   outlineColor: 'transparent',

--- a/src/recipes/toggleinput.ts
+++ b/src/recipes/toggleinput.ts
@@ -5,7 +5,7 @@ const toggleInputBase = {
   ...globalBaseStyles,
   display: 'grid',
   gap: '8',
-  gridTemplateColumns: '40px auto',
+  gridTemplateColumns: '[40px auto]',
   userSelect: 'none',
 };
 

--- a/src/recipes/toggleinput.ts
+++ b/src/recipes/toggleinput.ts
@@ -1,17 +1,17 @@
-import { defineRecipe } from "@pandacss/dev";
+import { defineRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const toggleInputBase = {
-    display: 'grid',
-    gap: '8',
-    gridTemplateColumns: '40px auto',
-    userSelect: 'none',
-}
+  ...globalBaseStyles,
+  display: 'grid',
+  gap: '8',
+  gridTemplateColumns: '40px auto',
+  userSelect: 'none',
+};
 
 export const toggleInputRecipe = defineRecipe({
-    className: 'toggle-input',
-    jsx: ["ToggleInput"],
-    base: toggleInputBase,
-    variants: {
-
-    }
-})
+  className: 'toggle-input',
+  jsx: ['ToggleInput'],
+  base: toggleInputBase,
+  variants: {},
+});

--- a/src/recipes/tooltip.ts
+++ b/src/recipes/tooltip.ts
@@ -1,4 +1,5 @@
 import { defineSlotRecipe } from '@pandacss/dev';
+import { globalBaseStyles } from '~/styles/utilities';
 
 const tooltipBase = {
   wrapper: {
@@ -9,6 +10,7 @@ const tooltipBase = {
     cursor: 'default',
   },
   tooltipContent: {
+    ...globalBaseStyles,
     display: 'flex',
     flexDirection: 'column',
     gap: '4',
@@ -144,8 +146,8 @@ const tooltipVariants = {
         },
       },
     },
-    'top-end':{
-      tooltipContent:{
+    'top-end': {
+      tooltipContent: {
         bottom: '100%',
         right: '0',
         _after: {
@@ -154,7 +156,7 @@ const tooltipVariants = {
           transform: 'translate(0, -2%)',
           borderTopColor: { base: 'slate.90', _dark: 'slate.0' },
         },
-      }
+      },
     },
     'bottom-end': {
       tooltipContent: {
@@ -203,37 +205,38 @@ export const tooltipRecipe = defineSlotRecipe({
   jsx: ['Tooltip'],
   slots: ['wrapper', 'tooltipContent'],
   base: tooltipBase,
-  variants: {...tooltipVariants,
-    caret:{
-      true:{
-        tooltipContent:{
-          _after:{
+  variants: {
+    ...tooltipVariants,
+    caret: {
+      true: {
+        tooltipContent: {
+          _after: {
             display: 'block',
-          }
+          },
         },
-        _position:{
-          top:{
-            tooltipContent:{
+        _position: {
+          top: {
+            tooltipContent: {
               mb: '12',
-            }
-          }
-        }
-      },
-      false:{
-        tooltipContent:{
-          _after:{
-            display: 'none',
-          }
+            },
+          },
         },
-        _position:{
-          top:{
-            tooltipContent:{
-              mb: '8'
-            }
-          }
-        }
-      }
-    }
+      },
+      false: {
+        tooltipContent: {
+          _after: {
+            display: 'none',
+          },
+        },
+        _position: {
+          top: {
+            tooltipContent: {
+              mb: '8',
+            },
+          },
+        },
+      },
+    },
   },
   defaultVariants: {
     position: 'bottom',

--- a/src/storybook/tokens/colorTokens.mdx
+++ b/src/storybook/tokens/colorTokens.mdx
@@ -814,7 +814,7 @@ import { SemanticColorToken } from './components/SemanticColorToken';
     ## Legacy Semantic Colors
 
     <Card variant="sunken" p="12" bg="bg.warning" rounded="8" border="border.warning" w="fit" maxW="full" display="flex" alignItems="center" gap="8" mx="auto">
-      <Icon name="warning" size="24" color="icon.warning" />
+      <Icon name="warning" size="24" fill="icon.warning" />
       <Text as="p" color="text.warning" lineHeight="tight">Legacy semantic color tokens are deprecated and will be removed in a future release.</Text>
     </Card>
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,3 @@
-@layer reset, base, tokens, recipes, utilities;
+@layer legacy, reset, base, tokens, recipes, utilities;
 
 @import 'font-imports.css';

--- a/src/styles/primitives/fontSizes.ts
+++ b/src/styles/primitives/fontSizes.ts
@@ -1,6 +1,7 @@
 import { defineTokens } from '@pandacss/dev';
 
 export const fontSizes = defineTokens.fontSizes({
+  '10': { value: '{sizes.10}' },
   '12': { value: '{sizes.12}' },
   '14': { value: '{sizes.14}' },
   '16': { value: '{sizes.16}' },

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,0 +1,147 @@
+/**
+ * includes some normalize styles from:
+ * https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+
+  &:is(:focus-visible, [data-focus-visible='true']) {
+    outline-color: var(--cetec-colors-border-focused);
+  }
+
+  &:is(:disabled, [disabled], [data-disabled], [aria-disabled='true']) {
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+}
+
+html {
+  --global-font-heading: var(--cetec-fonts-heading);
+  --global-font-body: var(--cetec-fonts-body);
+  --global-font-mono: var(--cetec-fonts-mono);
+  --cetec-font-variant-body: 'MONO' 0, 'CRSV' 0, 'CASL' 0, 'slnt' 0;
+  --cetec-font-variant-body-italic: 'MONO' 0, 'CRSV' 1, 'CASL' 0, 'slnt' -15;
+  --cetec-font-variant-body-casual: 'MONO' 0, 'CRSV' 1, 'CASL' 1, 'slnt' 0;
+  --cetec-font-variant-body-casual-italic:
+    'MONO' 0, 'CRSV' 1, 'CASL' 1, 'slnt' -15;
+  --cetec-font-variant-mono: 'MONO' 1, 'CRSV' 0, 'CASL' 0, 'slnt' 0;
+  --cetec-font-variant-mono-italic: 'MONO' 1, 'CRSV' 1, 'CASL' 0, 'slnt' -15;
+  --cetec-font-variant-mono-casual: 'MONO' 1, 'CRSV' 1, 'CASL' 1, 'slnt' 0;
+  --cetec-font-variant-mono-casual-italic:
+    'MONO' 1, 'CRSV' 1, 'CASL' 1, 'slnt' -15;
+  font-size: var(--cetec-font-sizes-16);
+  line-height: var(--cetec-line-heights-default);
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+}
+
+body {
+  font-family: var(--cetec-fonts-body);
+  font-variation-settings: var(--cetec-font-variant-body);
+  background: var(--cetec-colors-surface);
+  color: var(--cetec-colors-text-subtlest);
+  font-weight: var(--cetec-font-weights-normal);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--cetec-colors-text);
+  font-weight: var(--cetec-font-weights-black);
+  line-height: var(--cetec-line-heights-default);
+}
+
+p {
+  margin-bottom: 0.5rem;
+}
+
+b,
+strong {
+  font-weight: var(--cetec-font-weights-bold);
+}
+
+i,
+em {
+  font-style: italic;
+  font-variation-settings: var(--cetec-font-variant-body-italic);
+}
+
+u {
+  text-decoration: underline;
+}
+
+a {
+  text-decoration: none;
+}
+
+code,
+kbd,
+samp,
+pre {
+  font-family: var(--cetec-fonts-mono);
+  font-variation-settings: var(--cetec-font-variant-mono);
+  font-size: var(--cetec-font-sizes-16);
+}
+
+table {
+  border-color: var(--cetec-colors-border);
+}
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: var(--cetec-fonts-body);
+  font-size: 100%;
+  line-height: var(--cetec-line-heights-default);
+  margin: 0;
+}
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  appearance: button;
+  -webkit-appearance: button;
+}
+
+legend {
+  padding: 0;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type='search'] {
+  appearance: textfield;
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+summary {
+  display: list-item;
+}

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -3,145 +3,147 @@
  * https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css
  */
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+@layer reset {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
 
-  &:is(:focus-visible, [data-focus-visible='true']) {
-    outline-color: var(--cetec-colors-border-focused);
+    &:is(:focus-visible, [data-focus-visible='true']) {
+      outline-color: var(--cetec-colors-border-focused);
+    }
+
+    &:is(:disabled, [disabled], [data-disabled], [aria-disabled='true']) {
+      cursor: not-allowed;
+      pointer-events: none;
+    }
   }
 
-  &:is(:disabled, [disabled], [data-disabled], [aria-disabled='true']) {
-    cursor: not-allowed;
-    pointer-events: none;
+  html {
+    --global-font-heading: var(--cetec-fonts-heading);
+    --global-font-body: var(--cetec-fonts-body);
+    --global-font-mono: var(--cetec-fonts-mono);
+    --cetec-font-variant-body: 'MONO' 0, 'CRSV' 0, 'CASL' 0, 'slnt' 0;
+    --cetec-font-variant-body-italic: 'MONO' 0, 'CRSV' 1, 'CASL' 0, 'slnt' -15;
+    --cetec-font-variant-body-casual: 'MONO' 0, 'CRSV' 1, 'CASL' 1, 'slnt' 0;
+    --cetec-font-variant-body-casual-italic:
+      'MONO' 0, 'CRSV' 1, 'CASL' 1, 'slnt' -15;
+    --cetec-font-variant-mono: 'MONO' 1, 'CRSV' 0, 'CASL' 0, 'slnt' 0;
+    --cetec-font-variant-mono-italic: 'MONO' 1, 'CRSV' 1, 'CASL' 0, 'slnt' -15;
+    --cetec-font-variant-mono-casual: 'MONO' 1, 'CRSV' 1, 'CASL' 1, 'slnt' 0;
+    --cetec-font-variant-mono-casual-italic:
+      'MONO' 1, 'CRSV' 1, 'CASL' 1, 'slnt' -15;
+    font-size: var(--cetec-font-sizes-16);
+    line-height: var(--cetec-line-heights-default);
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
   }
-}
 
-html {
-  --global-font-heading: var(--cetec-fonts-heading);
-  --global-font-body: var(--cetec-fonts-body);
-  --global-font-mono: var(--cetec-fonts-mono);
-  --cetec-font-variant-body: 'MONO' 0, 'CRSV' 0, 'CASL' 0, 'slnt' 0;
-  --cetec-font-variant-body-italic: 'MONO' 0, 'CRSV' 1, 'CASL' 0, 'slnt' -15;
-  --cetec-font-variant-body-casual: 'MONO' 0, 'CRSV' 1, 'CASL' 1, 'slnt' 0;
-  --cetec-font-variant-body-casual-italic:
-    'MONO' 0, 'CRSV' 1, 'CASL' 1, 'slnt' -15;
-  --cetec-font-variant-mono: 'MONO' 1, 'CRSV' 0, 'CASL' 0, 'slnt' 0;
-  --cetec-font-variant-mono-italic: 'MONO' 1, 'CRSV' 1, 'CASL' 0, 'slnt' -15;
-  --cetec-font-variant-mono-casual: 'MONO' 1, 'CRSV' 1, 'CASL' 1, 'slnt' 0;
-  --cetec-font-variant-mono-casual-italic:
-    'MONO' 1, 'CRSV' 1, 'CASL' 1, 'slnt' -15;
-  font-size: var(--cetec-font-sizes-16);
-  line-height: var(--cetec-line-heights-default);
-  -webkit-text-size-adjust: 100%;
-  tab-size: 4;
-}
+  body {
+    font-family: var(--cetec-fonts-body);
+    font-variation-settings: var(--cetec-font-variant-body);
+    background: var(--cetec-colors-surface);
+    color: var(--cetec-colors-text-subtlest);
+    font-weight: var(--cetec-font-weights-normal);
+  }
 
-body {
-  font-family: var(--cetec-fonts-body);
-  font-variation-settings: var(--cetec-font-variant-body);
-  background: var(--cetec-colors-surface);
-  color: var(--cetec-colors-text-subtlest);
-  font-weight: var(--cetec-font-weights-normal);
-}
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--cetec-colors-text);
+    font-weight: var(--cetec-font-weights-black);
+    line-height: var(--cetec-line-heights-default);
+  }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: var(--cetec-colors-text);
-  font-weight: var(--cetec-font-weights-black);
-  line-height: var(--cetec-line-heights-default);
-}
+  p {
+    margin-bottom: 0.5rem;
+  }
 
-p {
-  margin-bottom: 0.5rem;
-}
+  b,
+  strong {
+    font-weight: var(--cetec-font-weights-bold);
+  }
 
-b,
-strong {
-  font-weight: var(--cetec-font-weights-bold);
-}
+  i,
+  em {
+    font-style: italic;
+    font-variation-settings: var(--cetec-font-variant-body-italic);
+  }
 
-i,
-em {
-  font-style: italic;
-  font-variation-settings: var(--cetec-font-variant-body-italic);
-}
+  u {
+    text-decoration: underline;
+  }
 
-u {
-  text-decoration: underline;
-}
+  a {
+    text-decoration: none;
+  }
 
-a {
-  text-decoration: none;
-}
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(--cetec-fonts-mono);
+    font-variation-settings: var(--cetec-font-variant-mono);
+    font-size: var(--cetec-font-sizes-16);
+  }
 
-code,
-kbd,
-samp,
-pre {
-  font-family: var(--cetec-fonts-mono);
-  font-variation-settings: var(--cetec-font-variant-mono);
-  font-size: var(--cetec-font-sizes-16);
-}
+  table {
+    border-color: var(--cetec-colors-border);
+  }
 
-table {
-  border-color: var(--cetec-colors-border);
-}
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: var(--cetec-fonts-body);
+    font-size: 100%;
+    line-height: var(--cetec-line-heights-default);
+    margin: 0;
+  }
 
-button,
-input,
-optgroup,
-select,
-textarea {
-  font-family: var(--cetec-fonts-body);
-  font-size: 100%;
-  line-height: var(--cetec-line-heights-default);
-  margin: 0;
-}
+  button,
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    appearance: button;
+    -webkit-appearance: button;
+  }
 
-button,
-[type='button'],
-[type='reset'],
-[type='submit'] {
-  appearance: button;
-  -webkit-appearance: button;
-}
+  legend {
+    padding: 0;
+  }
 
-legend {
-  padding: 0;
-}
+  progress {
+    vertical-align: baseline;
+  }
 
-progress {
-  vertical-align: baseline;
-}
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
 
-::-webkit-inner-spin-button,
-::-webkit-outer-spin-button {
-  height: auto;
-}
+  [type='search'] {
+    appearance: textfield;
+    -webkit-appearance: textfield;
+    outline-offset: -2px;
+  }
 
-[type='search'] {
-  appearance: textfield;
-  -webkit-appearance: textfield;
-  outline-offset: -2px;
-}
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
 
-::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    font: inherit;
+  }
 
-::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  font: inherit;
-}
-
-summary {
-  display: list-item;
+  summary {
+    display: list-item;
+  }
 }

--- a/src/styles/utilities/globalStyle.ts
+++ b/src/styles/utilities/globalStyle.ts
@@ -9,9 +9,6 @@ export const globalCss = defineGlobalStyles({
     boxSizing: 'border-box',
     margin: 0,
     padding: 0,
-    _focusVisible: {
-      outlineColor: { base: 'slate.90', _dark: 'slate.0' },
-    },
     _disabled: {
       cursor: 'not-allowed',
       pointerEvents: 'none',
@@ -26,74 +23,77 @@ export const globalCss = defineGlobalStyles({
     '-webkit-text-size-adjust': '100%',
     tabSize: '4',
   },
-  body: {
-    fontFamily: 'body',
+  '.random-class': {
     fontVariationSettings: fontVariants.body,
-    bg: { base: 'slate.0', _dark: 'slate.90' },
-    color: { base: 'slate.60', _dark: 'slate.30' },
-    fontWeight: 'normal',
   },
-  'h1, h2, h3, h4, h5, h6': {
-    color: { base: 'slate.90', _dark: 'slate.5' },
-    fontWeight: 'black',
-    lineHeight: 'calc(1em + 0.5rem)',
-  },
-  p: {
-    marginBottom: '0.5rem',
-  },
-  'b, strong': {
-    fontWeight: 'bold',
-  },
-  'i, em': {
-    fontStyle: 'italic',
-    fontVariationSettings: fontVariants['body-italic'],
-  },
-  u: {
-    textDecoration: 'underline',
-  },
-  a: {
-    textDecoration: 'none',
-  },
-  'code, kbd, samp, pre': {
-    fontFamily: 'mono',
-    fontVariationSettings: fontVariants.mono,
-    fontSize: '1em',
-  },
-  table: {
-    borderColor: { base: 'slate.10', _dark: 'slate.60' },
-  },
-  'button, input, optgroup, select, textarea': {
-    fontFamily: 'body',
-    fontSize: '100%',
-    lineHeight: 'calc(1em + 0.5rem)',
-    margin: '0',
-  },
-  'button, [type="button"], [type="reset"], [type="submit"]': {
-    appearance: 'button',
-    '-webkit-appearance': 'button',
-  },
-  legend: {
-    padding: '0',
-  },
-  progress: {
-    verticalAlign: 'baseline',
-  },
-  '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
-    height: 'auto',
-  },
-  '[type="search"]': {
-    appearance: 'textfield',
-    '-webkit-appearance': 'textfield',
-    outlineOffset: '-2px',
-  },
-  '::-webkit-search-decoration': {
-    '-webkit-appearance': 'none',
-  },
-  '::-webkit-file-upload-button': {
-    '-webkit-appearance': 'button',
-    font: 'inherit',
-  },
-  summary: {
-    display: 'list-item',
-  },
+
+  // body: {
+  // fontFamily: 'body',
+  // bg: { base: 'slate.0', _dark: 'slate.90' },
+  // color: { base: 'slate.60', _dark: 'slate.30' },
+  // fontWeight: 'normal',
+  // },
+  // 'h1, h2, h3, h4, h5, h6': {
+  //   color: { base: 'slate.90', _dark: 'slate.5' },
+  //   fontWeight: 'black',
+  //   lineHeight: 'calc(1em + 0.5rem)',
+  // },
+  // p: {
+  //   marginBottom: '0.5rem',
+  // },
+  // 'b, strong': {
+  //   fontWeight: 'bold',
+  // },
+  // 'i, em': {
+  //   fontStyle: 'italic',
+  //   fontVariationSettings: fontVariants['body-italic'],
+  // },
+  // u: {
+  //   textDecoration: 'underline',
+  // },
+  // a: {
+  //   textDecoration: 'none',
+  // },
+  // 'code, kbd, samp, pre': {
+  //   fontFamily: 'mono',
+  //   fontVariationSettings: fontVariants.mono,
+  //   fontSize: '1em',
+  // },
+  // table: {
+  //   borderColor: { base: 'slate.10', _dark: 'slate.60' },
+  // },
+  // 'button, input, optgroup, select, textarea': {
+  //   fontFamily: 'body',
+  //   fontSize: '100%',
+  //   lineHeight: 'calc(1em + 0.5rem)',
+  //   margin: '0',
+  // },
+  // 'button, [type="button"], [type="reset"], [type="submit"]': {
+  //   appearance: 'button',
+  //   '-webkit-appearance': 'button',
+  // },
+  // legend: {
+  //   padding: '0',
+  // },
+  // progress: {
+  //   verticalAlign: 'baseline',
+  // },
+  // '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
+  //   height: 'auto',
+  // },
+  // '[type="search"]': {
+  //   appearance: 'textfield',
+  //   '-webkit-appearance': 'textfield',
+  //   outlineOffset: '-2px',
+  // },
+  // '::-webkit-search-decoration': {
+  //   '-webkit-appearance': 'none',
+  // },
+  // '::-webkit-file-upload-button': {
+  //   '-webkit-appearance': 'button',
+  //   font: 'inherit',
+  // },
+  // summary: {
+  //   display: 'list-item',
+  // },
 });

--- a/src/styles/utilities/globalStyle.ts
+++ b/src/styles/utilities/globalStyle.ts
@@ -6,8 +6,6 @@ import { defineGlobalStyles } from '@pandacss/dev';
 export const globalCss = defineGlobalStyles({
   '*, *::before, *::after': {
     boxSizing: 'border-box',
-    margin: 0,
-    padding: 0,
     _disabled: {
       cursor: 'not-allowed',
       pointerEvents: 'none',
@@ -31,9 +29,7 @@ export const globalCss = defineGlobalStyles({
       '"MONO" 1, "CRSV" 1, "CASL" 1, "slnt" 0',
     '--cetec-font-variant-mono-casual-italic':
       '"MONO" 1, "CRSV" 1, "CASL" 1, "slnt" -15',
-    fontSize: '16',
-    lineHeight: 'var(--cetec-line-heights-default)',
-    '-webkit-text-size-adjust': '100%',
-    tabSize: '4',
+    '--cetec-base-font-size': 'var(--cetec-font-sizes-16)',
+    fontSize: 'var(--cetec-base-font-size)',
   },
 });

--- a/src/styles/utilities/globalStyle.ts
+++ b/src/styles/utilities/globalStyle.ts
@@ -1,5 +1,4 @@
 import { defineGlobalStyles } from '@pandacss/dev';
-import { fontVariants } from './fontVariants';
 
 // includes some normalize styles from:
 // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css
@@ -15,85 +14,26 @@ export const globalCss = defineGlobalStyles({
     },
   },
   html: {
-    '--global-font-heading': 'heading',
-    '--global-font-body': 'body',
-    '--global-font-mono': 'mono',
+    '--global-font-heading': 'var(--cetec-fonts-heading)',
+    '--global-font-body': 'var(--cetec-fonts-body)',
+    '--global-font-mono': 'var(--cetec-fonts-mono)',
+    '--cetec-font-variant-body': '"MONO" 0, "CRSV" 0, "CASL" 0, "slnt" 0',
+    '--cetec-font-variant-body-italic':
+      '"MONO" 0, "CRSV" 1, "CASL" 0, "slnt" -15',
+    '--cetec-font-variant-body-casual':
+      '"MONO" 0, "CRSV" 1, "CASL" 1, "slnt" 0',
+    '--cetec-font-variant-body-casual-italic':
+      '"MONO" 0, "CRSV" 1, "CASL" 1, "slnt" -15',
+    '--cetec-font-variant-mono': '"MONO" 1, "CRSV" 0, "CASL" 0, "slnt" 0',
+    '--cetec-font-variant-mono-italic':
+      '"MONO" 1, "CRSV" 1, "CASL" 0, "slnt" -15',
+    '--cetec-font-variant-mono-casual':
+      '"MONO" 1, "CRSV" 1, "CASL" 1, "slnt" 0',
+    '--cetec-font-variant-mono-casual-italic':
+      '"MONO" 1, "CRSV" 1, "CASL" 1, "slnt" -15',
     fontSize: '16',
-    lineHeight: 'calc(1em + 0.5rem)',
+    lineHeight: 'var(--cetec-line-heights-default)',
     '-webkit-text-size-adjust': '100%',
     tabSize: '4',
   },
-  '.random-class': {
-    fontVariationSettings: fontVariants.body,
-  },
-
-  // body: {
-  // fontFamily: 'body',
-  // bg: { base: 'slate.0', _dark: 'slate.90' },
-  // color: { base: 'slate.60', _dark: 'slate.30' },
-  // fontWeight: 'normal',
-  // },
-  // 'h1, h2, h3, h4, h5, h6': {
-  //   color: { base: 'slate.90', _dark: 'slate.5' },
-  //   fontWeight: 'black',
-  //   lineHeight: 'calc(1em + 0.5rem)',
-  // },
-  // p: {
-  //   marginBottom: '0.5rem',
-  // },
-  // 'b, strong': {
-  //   fontWeight: 'bold',
-  // },
-  // 'i, em': {
-  //   fontStyle: 'italic',
-  //   fontVariationSettings: fontVariants['body-italic'],
-  // },
-  // u: {
-  //   textDecoration: 'underline',
-  // },
-  // a: {
-  //   textDecoration: 'none',
-  // },
-  // 'code, kbd, samp, pre': {
-  //   fontFamily: 'mono',
-  //   fontVariationSettings: fontVariants.mono,
-  //   fontSize: '1em',
-  // },
-  // table: {
-  //   borderColor: { base: 'slate.10', _dark: 'slate.60' },
-  // },
-  // 'button, input, optgroup, select, textarea': {
-  //   fontFamily: 'body',
-  //   fontSize: '100%',
-  //   lineHeight: 'calc(1em + 0.5rem)',
-  //   margin: '0',
-  // },
-  // 'button, [type="button"], [type="reset"], [type="submit"]': {
-  //   appearance: 'button',
-  //   '-webkit-appearance': 'button',
-  // },
-  // legend: {
-  //   padding: '0',
-  // },
-  // progress: {
-  //   verticalAlign: 'baseline',
-  // },
-  // '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
-  //   height: 'auto',
-  // },
-  // '[type="search"]': {
-  //   appearance: 'textfield',
-  //   '-webkit-appearance': 'textfield',
-  //   outlineOffset: '-2px',
-  // },
-  // '::-webkit-search-decoration': {
-  //   '-webkit-appearance': 'none',
-  // },
-  // '::-webkit-file-upload-button': {
-  //   '-webkit-appearance': 'button',
-  //   font: 'inherit',
-  // },
-  // summary: {
-  //   display: 'list-item',
-  // },
 });

--- a/src/styles/utilities/index.ts
+++ b/src/styles/utilities/index.ts
@@ -11,3 +11,5 @@ export * from './textStyles';
 export * from './filters';
 export * from './fontVariants';
 export * from './transitions';
+
+export * from './recipeGlobalStyles';

--- a/src/styles/utilities/recipeGlobalStyles.ts
+++ b/src/styles/utilities/recipeGlobalStyles.ts
@@ -1,6 +1,9 @@
 import { fontVariants } from './fontVariants';
 
 export const globalBaseStyles = {
+  boxSizing: 'border-box',
+  margin: 0,
+  padding: 0,
   fontFamily: 'body',
   fontVariationSettings: fontVariants.body,
   fontWeight: 'normal',

--- a/src/styles/utilities/recipeGlobalStyles.ts
+++ b/src/styles/utilities/recipeGlobalStyles.ts
@@ -1,0 +1,10 @@
+import { defineStyles } from '@pandacss/dev';
+import { fontVariants } from './fontVariants';
+
+export const globalBaseStyles = defineStyles({
+  fontFamily: 'body',
+  fontVariationSettings: fontVariants.body,
+  fontWeight: 'normal',
+  lineHeight: 'default',
+  color: 'text.subtlest',
+});

--- a/src/styles/utilities/recipeGlobalStyles.ts
+++ b/src/styles/utilities/recipeGlobalStyles.ts
@@ -1,10 +1,9 @@
-import { defineStyles } from '@pandacss/dev';
 import { fontVariants } from './fontVariants';
 
-export const globalBaseStyles = defineStyles({
+export const globalBaseStyles = {
   fontFamily: 'body',
   fontVariationSettings: fontVariants.body,
   fontWeight: 'normal',
   lineHeight: 'default',
   color: 'text.subtlest',
-});
+};

--- a/src/styles/utilities/textStyles.ts
+++ b/src/styles/utilities/textStyles.ts
@@ -1,5 +1,5 @@
 import { defineTextStyles } from '@pandacss/dev';
-import { fontVariants } from '.';
+import { fontVariants } from './fontVariants';
 
 export const baseHeadingStyles = {
   fontFamily: 'heading',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,10 @@ export default defineConfig(({ mode: _mode, command }) => {
                   src: 'src/types/index.d.ts',
                   dest: './',
                 },
+                {
+                  src: 'src/styles/reset.css',
+                  dest: './',
+                },
               ],
             }),
           ]


### PR DESCRIPTION
This abstracts out the global styles that were causing styles to leak out in consuming apps. In particular, the styles using naked tag selectors in the `globalStyles.ts` file. This should have no visible effect on the components themselves.

The tag-based styles that were removed are still available in the published package:
`/dist/reset.css` 