### PR TITLE
feat(patch): add click-and-hover trigger interaction to Menu

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -308,9 +308,15 @@ export const SubMenuHover: Story = {
   parameters: { controls: { disable: true } },
 };
 
-export const TopNavHoverTrigger: Story = {
-  name: 'Top nav hover trigger',
-  render: () => (
+const TopNavExampleWrapper = () => {
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  const getMenuProps = (id: string) => ({
+    open: openMenu === id,
+    onOpenChange: (open: boolean) => setOpenMenu(open ? id : null),
+  });
+
+  return (
     <VStack
       alignItems="stretch"
       minW="3xl"
@@ -329,10 +335,11 @@ export const TopNavHoverTrigger: Story = {
         py="16"
       >
         <Menu
-          triggerInteraction="hover"
+          triggerInteraction="click-and-hover"
           trigger={<Button variant="selectedBold">Sales</Button>}
           subMenuInteraction="hover"
           closeOnSelect={false}
+          {...getMenuProps('sales')}
         >
           <SubMenu label="Quotes">
             <MenuItem label="Open quotes" />
@@ -354,11 +361,54 @@ export const TopNavHoverTrigger: Story = {
           </SubMenu>
         </Menu>
 
-        <Button>Production</Button>
-        <Button>Admin</Button>
+        <Menu
+          triggerInteraction="click-and-hover"
+          trigger={<Button>Production</Button>}
+          subMenuInteraction="hover"
+          closeOnSelect={false}
+          {...getMenuProps('production')}
+        >
+          <SubMenu label="Work Orders">
+            <MenuItem label="Open work orders" />
+            <MenuItem label="Completed" />
+          </SubMenu>
+
+          <SubMenu label="Scheduling">
+            <MenuItem label="Production schedule" />
+            <MenuItem label="Resource calendar" />
+          </SubMenu>
+
+          <MenuItem label="Inventory" />
+        </Menu>
+
+        <Menu
+          triggerInteraction="click-and-hover"
+          trigger={<Button>Admin</Button>}
+          subMenuInteraction="hover"
+          closeOnSelect={false}
+          {...getMenuProps('admin')}
+        >
+          <SubMenu label="Users">
+            <MenuItem label="All users" />
+            <MenuItem label="Roles & permissions" />
+          </SubMenu>
+
+          <SubMenu label="Settings">
+            <MenuItem label="General" />
+            <MenuItem label="Integrations" />
+            <MenuItem label="Billing" />
+          </SubMenu>
+
+          <MenuItem label="Audit log" iconBefore="list-bullets" />
+        </Menu>
       </HStack>
     </VStack>
-  ),
+  );
+};
+
+export const TopNavExample: Story = {
+  name: 'Top nav example',
+  render: () => <TopNavExampleWrapper />,
   parameters: { controls: { disable: true } },
 };
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -122,12 +122,13 @@ export const Menu = (props: MenuProps) => {
   const isMenuVisible = hasReference ? isOpen : true;
 
   const setOpenState = (nextOpen: boolean, _event?: Event, reason?: string) => {
-    if (
-      triggerInteraction === 'hover' &&
-      !nextOpen &&
-      (reason === 'hover' || reason === 'safe-polygon')
-    ) {
-      return;
+    if (!nextOpen && (reason === 'hover' || reason === 'safe-polygon')) {
+      if (
+        triggerInteraction === 'hover' ||
+        triggerInteraction === 'click-and-hover'
+      ) {
+        return;
+      }
     }
 
     if (!isControlled) {
@@ -168,7 +169,10 @@ export const Menu = (props: MenuProps) => {
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   const hover = useHover(floating.context, {
-    enabled: hasReference && triggerInteraction === 'hover',
+    enabled:
+      hasReference &&
+      (triggerInteraction === 'hover' ||
+        triggerInteraction === 'click-and-hover'),
     delay: {
       open: triggerOpenDelay,
       close: triggerCloseDelay,
@@ -178,7 +182,10 @@ export const Menu = (props: MenuProps) => {
     }),
   });
   const click = useClick(floating.context, {
-    enabled: hasReference && triggerInteraction === 'click',
+    enabled:
+      hasReference &&
+      (triggerInteraction === 'click' ||
+        triggerInteraction === 'click-and-hover'),
   });
   const dismiss = useDismiss(floating.context, { enabled: hasReference });
   const role = useRole(floating.context, { role: 'menu' });

--- a/src/components/Menu/context/menuContext.ts
+++ b/src/components/Menu/context/menuContext.ts
@@ -19,7 +19,7 @@ import type { Placement } from '@floating-ui/react';
 export type MenuDensity = 'compact' | 'comfortable' | 'spacious';
 export type MenuFilterMode = 'none' | 'contains';
 export type SubMenuInteraction = 'hover' | 'digin';
-export type MenuTriggerInteraction = 'click' | 'hover';
+export type MenuTriggerInteraction = 'click' | 'hover' | 'click-and-hover';
 
 export type MenuProps = {
   trigger?: ReactElement;


### PR DESCRIPTION
## Summary

- Adds `'click-and-hover'` as a third `MenuTriggerInteraction` value, enabling both hover and click on the same trigger
- Hover opens/closes naturally; click also opens and toggles; hover-away and safe-polygon closes are suppressed so menus only close via dismiss or consumer-controlled state
- Fixes flashing on initial hover and nested submenu collapse caused by unsuppressed safe-polygon close events
- Updates `TopNavHoverTrigger` story to `TopNavExample` with `click-and-hover` and controlled sibling coordination across Sales, Production, and Admin menus

## Test plan

- [ ] Hover over a top nav item — menu opens without flashing
- [ ] Move cursor into the menu and hover over nested submenus — deep submenus open and stay open
- [ ] Click a top nav item — menu stays open when hovering away
- [ ] Hover to a sibling nav item — previous menu closes, sibling opens
- [ ] Press Escape or click outside — menu closes
- [ ] Existing `hover` and `click` trigger modes are unchanged