### PR TITLE
refactor: pass href prop to render listitem as anchor

### DIFF
--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -245,6 +245,26 @@ export const Highlighting: Story = {
   parameters: { controls: { disable: true } },
 };
 
+export const WithHrefs: Story = {
+  args: {},
+  render: () => (
+    <Card variant="flat" minW="2xs">
+      <List role="listbox" aria-label="Navigation links">
+        {items.map((item) => (
+          <ListItem
+            key={`link-${item.id}`}
+            href={`#${item.id}`}
+            iconAfter="arrow-square-out"
+            label={item.label}
+            description={item.desc}
+          />
+        ))}
+      </List>
+    </Card>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
 export const ConditionalBreakpoints: Story = {
   args: {},
   render: () => (

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -18,9 +18,10 @@ import { type ListDensity, useListContext } from './listContext';
 
 export type ListItemProps = Omit<
   BoxProps<'button'>,
-  keyof ListItemVariantProps | 'as' | 'type'
+  keyof ListItemVariantProps | 'as' | 'type' | 'href'
 > &
   Omit<ListItemVariantProps, 'selected' | 'iconBefore' | 'iconAfter'> & {
+    href?: string;
     label?: string;
     description?: string;
     query?: string;
@@ -48,6 +49,7 @@ export const ListItem = (props: ListItemProps) => {
     children,
     iconBefore,
     iconAfter,
+    href,
     ...rest
   } = props;
   const [className, otherProps] = splitProps(rest);
@@ -81,8 +83,15 @@ export const ListItem = (props: ListItemProps) => {
 
   return (
     <Box
-      as="button"
-      type="button"
+      {...(href
+        ? ({
+            as: 'a',
+            href,
+          } satisfies BoxProps<'a'>)
+        : ({
+            as: 'button',
+            type: 'button',
+          } satisfies BoxProps<'button'>))}
       className={cx(classes.wrapper, className)}
       role="option"
       aria-selected={isSelected}


### PR DESCRIPTION
https://internal.cetecerpbeta.com/otd/customercomplaint/38334/edit
https://internal.cetecerpbeta.com/otd/customercomplaint/38364/edit

Some reports of users and internal people wanting the ability to right click global search results in order to open them in new tabs/windows.

Shouldn't require refactoring anywhere the component is being used, because the prop is optional.