### PR TITLE
feat(minor): add uncontrolled support and static-safe visuals for form components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ export type CheckboxProps = Omit<BoxProps, keyof CheckboxVariantProps> &
 
 **Function Components Only:** No class components, use hooks for state/effects
 
-**Controlled Components:** Use controlled pattern for all form inputs (checkboxes, radios, text inputs)
+**Controlled vs Uncontrolled:** Prefer controlled state when the UI needs React to own the current value. Use uncontrolled entrypoints when the browser can own the value safely, especially for native inputs and binary controls (`Checkbox`, `Radio`, `Toggle`) and for group/value components that expose `defaultChecked`, `defaultValue`, or `defaultOpen`.
 
 **Accessibility Baseline:**
 
@@ -255,7 +255,8 @@ export { buttonRecipe } from './recipes/button';
 ### Storybook Documentation Strategy
 
 - **Public primitive stories first:** Use primitive component names as Storybook entry points for controls (`Checkbox`, `Radio`, `Toggle`) instead of only wrapper entries.
-- **Wrapper guidance inside primitive stories:** Demonstrate `CheckboxInput`, `RadioInput`, and `ToggleInput` usage inside those primitive stories to teach composition patterns.
+- **Wrapper guidance inside primitive stories:** Demonstrate `CheckboxInput`, `RadioInput`, and `ToggleInput` usage inside those primitive stories to teach composition patterns, and show both controlled and uncontrolled examples where the API supports both.
+- **Static-safe examples:** When a component supports `defaultChecked`, `defaultValue`, or `defaultOpen`, include at least one story that exercises the uncontrolled path so consumers can see what works without hydration.
 - **Beginner-first story structure:** Each component story should explain when to use it, when not to use it, include a minimal copy-paste snippet, and include at least one realistic app example.
 - **Accessibility is explicit:** Add keyboard and labeling examples in stories for interactive components.
 - **Foundations are visible:** `Box` should have a dedicated story because it is a frequently used primitive; link it to Panda layout/pattern docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Icons are managed as an SVG sprite system:
 - **Strict TypeScript**: No ambient `any`; isolate escapes with TODO comments
 - **Composition > prop soup**: Small components that compose; avoid mega-props
 - **Function components only**: Hooks for state/effects; no legacy lifecycles
-- **Controlled components**: Use controlled components as the standard pattern for form inputs, including checkboxes, radios, text inputs, and other interactive elements.
+- **Controlled vs uncontrolled**: Prefer controlled state when the UI needs React to own the current value. Use uncontrolled entrypoints when the browser can own the value safely, especially for native inputs and binary controls (`Checkbox`, `Radio`, `Toggle`) and for group/value components that expose `defaultChecked`, `defaultValue`, or `defaultOpen`.
 - **Props typing**: Use `React.ComponentProps<"element">` for intrinsic elements
 
 ### Git Conventions (from `.cursor/rules/git.mdc`)
@@ -197,7 +197,7 @@ Projects consuming this design system must:
 4. Standard `recipes` are registered automatically, but new `slotRecipes` need to be manually registered in `panda.config.ts` under `theme.extend.recipes`
 5. Run `npm run prepare` to regenerate Panda CSS types
 6. Implement component using the recipe
-7. Create Storybook stories
+7. Create Storybook stories, including uncontrolled examples when the API supports them
 8. Export from `src/index.ts`
 
 ### Modifying Design Tokens

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ This design system is built on **Panda CSS** with a strict tokens-first approach
 - Type props with TypeScript strict mode
 - Style with Panda recipes (no inline styles or hard-coded values)
 - Follow accessibility guidelines (semantic HTML, keyboard support, ARIA when needed)
+- Native form controls support both controlled and uncontrolled usage where it fits the element semantics. Use `checked` / `value` when React owns the state, and `defaultChecked` / `defaultValue` / `defaultOpen` when the browser or widget should own the initial state.
+- Binary and group-based controls (`Checkbox`, `Radio`, `Toggle`, `Select`, `DatePicker`, `TimePicker`, `ChipGroup`) now expose explicit uncontrolled entrypoints so static pages can avoid hydration when they do not need React state.
 
 Also see [Component Standards](./src/storybook/docs/componentStandards.mdx)
 

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Use `CheckboxInput` for app forms so labels, spacing, and click targets are wired by default. Use `Checkbox` only when building a custom composed wrapper.',
+          'Use `CheckboxInput` for app forms so labels, spacing, and click targets are wired by default. Use `Checkbox` only when building a custom composed wrapper. Both controlled and uncontrolled usage are supported.',
       },
     },
   },
@@ -64,6 +64,18 @@ export const Default: Story = {
           'Recommended default for product UI: `CheckboxInput` with visible label copy.',
       },
     },
+  },
+};
+
+export const Uncontrolled: Story = {
+  name: 'Uncontrolled',
+  render: () => (
+    <CheckboxInput name="uncontrolled" id="uncontrolled" defaultChecked>
+      Remember this choice
+    </CheckboxInput>
+  ),
+  parameters: {
+    controls: { disable: true },
   },
 };
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent } from 'react';
+import { useEffect, useRef, type ChangeEvent } from 'react';
 
 import { cx } from '@styled-system/css';
 import { checkbox, type CheckboxVariantProps } from '@styled-system/recipes';
@@ -11,12 +11,13 @@ import { Icon } from '../Icon';
 
 export type CheckboxProps = Omit<
   BoxProps,
-  'checked' | 'onChange' | keyof CheckboxVariantProps
+  'checked' | 'defaultChecked' | 'onChange' | keyof CheckboxVariantProps
 > &
   CheckboxVariantProps & {
     name: string;
-    checked: boolean;
-    onChange: CheckboxChangeHandler;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onChange?: CheckboxChangeHandler;
     id?: string;
     error?: boolean;
     invalid?: boolean;
@@ -39,22 +40,23 @@ export type CheckboxChangeEvent = ChangeEvent<HTMLInputElement>;
 export type CheckboxChangeHandler = (e: CheckboxChangeEvent) => void;
 
 /**
- * Checkbox is a controlled component.
- * You must pass `checked` and `onChange` props.
+ * Checkbox supports both controlled and uncontrolled usage.
+ *
+ * @example
+ * <Checkbox defaultChecked />
  *
  * @example
  * const [checked, setChecked] = useState(false);
- * <Checkbox
- *   checked={checked}
- *   onChange={(e) => setChecked(e.target.checked)}
- * />
+ * <Checkbox checked={checked} onChange={(e) => setChecked(e.target.checked)} />
  */
 
 export const Checkbox = (props: CheckboxProps) => {
   const fieldContext = useFieldContext();
+  const inputRef = useRef<HTMLInputElement>(null);
   const {
     name,
     checked,
+    defaultChecked,
     onChange,
     id,
     indeterminate,
@@ -78,12 +80,13 @@ export const Checkbox = (props: CheckboxProps) => {
     checkBg,
   });
 
-  // Determine which icon to render based on state
-  const iconName = indeterminate
-    ? 'checkbox-indeterminate'
-    : checked
-      ? 'checkbox-checked'
-      : 'checkbox';
+  const isControlled = checked !== undefined;
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = Boolean(indeterminate);
+    }
+  }, [indeterminate]);
 
   return (
     <Box
@@ -93,21 +96,31 @@ export const Checkbox = (props: CheckboxProps) => {
     >
       <Box
         as="input"
+        ref={inputRef}
         type="checkbox"
         className={classes.input}
         name={name}
         id={id}
-        checked={checked}
+        {...(isControlled
+          ? { checked }
+          : { defaultChecked: defaultChecked ?? false })}
         onChange={onChange}
         disabled={disabled}
+        aria-checked={indeterminate ? 'mixed' : undefined}
         {...(indeterminate && { 'data-indeterminate': true })}
         {...(error && { 'data-error': true })}
         {...(invalid && { 'data-invalid': true, 'aria-invalid': true })}
         {...otherProps}
       />
-      <Icon className={classes.checkBg} name="square" />
-      <Icon className={classes.indicator} name={iconName} />
-      <Icon className={classes.indicator} name="checkbox-focus" />
+      <Icon className={classes.checkBg} name="square" aria-hidden />
+      <Icon className={classes.indicator} name="checkbox" aria-hidden />
+      <Icon className={classes.indicator} name="checkbox-checked" aria-hidden />
+      <Icon
+        className={classes.indicator}
+        name="checkbox-indeterminate"
+        aria-hidden
+      />
+      <Icon className={classes.indicator} name="checkbox-focus" aria-hidden />
     </Box>
   );
 };

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -21,8 +21,9 @@ export type CheckboxInputProps = Omit<
 > &
   CheckboxInputVariantProps & {
     name: string;
-    checked: boolean;
-    onChange: CheckboxChangeHandler;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onChange?: CheckboxChangeHandler;
     id?: string;
     error?: boolean;
     invalid?: boolean;
@@ -35,6 +36,7 @@ export const CheckboxInput = (props: CheckboxInputProps) => {
   const {
     name,
     checked,
+    defaultChecked,
     onChange,
     id,
     children,
@@ -60,6 +62,7 @@ export const CheckboxInput = (props: CheckboxInputProps) => {
       <Checkbox
         name={name}
         checked={checked}
+        defaultChecked={defaultChecked}
         onChange={onChange}
         id={resolvedId}
         error={error}

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -83,6 +83,20 @@ export const Default: Story = {
   render: () => <Chip>Default</Chip>,
 };
 
+export const UncontrolledGroup: Story = {
+  name: 'Uncontrolled Group',
+  render: () => (
+    <ChipGroup type="single" defaultValue="growth" label="Plan size">
+      <Chip value="starter">Starter</Chip>
+      <Chip value="growth">Growth</Chip>
+      <Chip value="enterprise">Enterprise</Chip>
+    </ChipGroup>
+  ),
+  parameters: {
+    controls: { disable: true },
+  },
+};
+
 // =============================================================================
 // SIZES
 // =============================================================================

--- a/src/components/Chip/ChipGroup.tsx
+++ b/src/components/Chip/ChipGroup.tsx
@@ -13,6 +13,7 @@ import { Wrap, type WrapProps } from '@styled-system/jsx';
 import { type BoxProps } from '~/components/Box';
 import { useFieldContext } from '~/system/context/FieldContext';
 import { splitProps } from '~/utils/splitProps';
+import { useControllableState } from '~/utils/useControllableState';
 
 import {
   ChipGroupContext,
@@ -23,8 +24,9 @@ import {
 export type ChipGroupProps = Omit<WrapProps, 'role'> &
   Omit<BoxProps, keyof WrapProps> & {
     type: ChipGroupType;
-    value: string | string[];
-    onChange: (value: string | string[]) => void;
+    value?: string | string[];
+    defaultValue?: string | string[];
+    onChange?: (value: string | string[]) => void;
     children: ReactNode;
     size?: ChipGroupSize;
     label?: string;
@@ -42,6 +44,7 @@ export const ChipGroup = (props: ChipGroupProps) => {
   const {
     type,
     value,
+    defaultValue,
     onChange,
     children,
     size: sizeProp,
@@ -60,6 +63,11 @@ export const ChipGroup = (props: ChipGroupProps) => {
   const chipRefs = useRef<Map<string, RefObject<HTMLButtonElement | null>>>(
     new Map(),
   );
+  const [selectedValue, setSelectedValue] = useControllableState({
+    value,
+    defaultValue: defaultValue ?? (type === 'single' ? '' : ([] as string[])),
+    onChange,
+  });
   const [chipValues, setChipValues] = useState<string[]>([]);
 
   const registerChip = useCallback(
@@ -101,19 +109,19 @@ export const ChipGroup = (props: ChipGroupProps) => {
         nextRef?.current?.focus();
 
         if (type === 'single') {
-          onChange(nextValue);
+          setSelectedValue(nextValue);
         }
       }
     },
-    [chipValues, onChange, type],
+    [chipValues, setSelectedValue, type],
   );
 
   const contextValue = useMemo(
     () => ({
       type,
       size,
-      value,
-      onChange,
+      value: selectedValue,
+      onChange: setSelectedValue,
       name,
       registerChip,
       unregisterChip,
@@ -124,12 +132,12 @@ export const ChipGroup = (props: ChipGroupProps) => {
       chipValues,
       focusChip,
       name,
-      onChange,
+      selectedValue,
+      setSelectedValue,
       registerChip,
       size,
       type,
       unregisterChip,
-      value,
     ],
   );
 

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -50,6 +50,11 @@ export const WithValue: Story = {
   render: () => <DatePicker value={{ year: 2026, month: 2, day: 19 }} />,
 };
 
+export const WithDefaultValue: Story = {
+  name: 'With Default Value',
+  render: () => <DatePicker defaultValue={{ year: 2026, month: 2, day: 19 }} />,
+};
+
 export const WithMinMax: Story = {
   name: 'With Min/Max',
   render: () => (

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -177,6 +177,8 @@ export type DatePickerProps = Omit<
   DatePickerVariantProps & {
     /** Controlled value */
     value?: DateValue | null;
+    /** Initial uncontrolled value */
+    defaultValue?: DateValue | null;
     /** Called when the date changes */
     onChange?: (value: DateValue | null) => void;
     /** Earliest selectable date */
@@ -192,6 +194,8 @@ export type DatePickerProps = Omit<
     name?: string;
     /** Controlled popover open state */
     open?: boolean;
+    /** Initial uncontrolled popover state */
+    defaultOpen?: boolean;
     onOpenChange?: (open: boolean) => void;
     size?: DatePickerVariantProps['size'];
   };
@@ -202,6 +206,7 @@ export const DatePicker = (props: DatePickerProps) => {
   const fieldContext = useFieldContext();
   const {
     value,
+    defaultValue = null,
     onChange,
     minDate,
     maxDate,
@@ -212,6 +217,7 @@ export const DatePicker = (props: DatePickerProps) => {
     id,
     size: sizeProp,
     open: controlledOpen,
+    defaultOpen = false,
     onOpenChange,
     ...rest
   } = props;
@@ -221,12 +227,13 @@ export const DatePicker = (props: DatePickerProps) => {
   const size = sizeProp ?? fieldContext?.size;
 
   const [className, otherProps] = splitProps(rest);
+  const initialValue = value !== undefined ? value : defaultValue;
 
   // ── Segment state ──────────────────────────────────────────────────────────
   const [segments, setSegments] = useState<SegmentValues>(() => ({
-    month: value?.month ?? null,
-    day: value?.day ?? null,
-    year: value?.year ?? null,
+    month: initialValue?.month ?? null,
+    day: initialValue?.day ?? null,
+    year: initialValue?.year ?? null,
   }));
   const [rawInput, setRawInput] = useState<SegmentRaw>({
     month: '',
@@ -243,12 +250,12 @@ export const DatePicker = (props: DatePickerProps) => {
     return { year: now.getFullYear(), month: now.getMonth() + 1 };
   }, []);
   const [viewDate, setViewDate] = useState({
-    year: value?.year ?? today.year,
-    month: value?.month ?? today.month,
+    year: initialValue?.year ?? today.year,
+    month: initialValue?.month ?? today.month,
   });
 
   // ── Popover state ──────────────────────────────────────────────────────────
-  const [internalOpen, setInternalOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
   const isOpen = controlledOpen ?? internalOpen;
 
   const handleOpenChange = useCallback(

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Use `RadioInput` for product forms so each option includes a label and reliable hit area. Use `Radio` only for custom composition patterns.',
+          'Use `RadioInput` for product forms so each option includes a label and reliable hit area. Use `Radio` only for custom composition patterns. Both standalone and grouped usage are supported.',
       },
     },
   },
@@ -73,6 +73,31 @@ export const Default: Story = {
           'Recommended usage: `RadioInput` options in a controlled group with user-facing labels.',
       },
     },
+  },
+};
+
+export const Uncontrolled: Story = {
+  name: 'Uncontrolled',
+  render: function UncontrolledRender() {
+    const groupId = useId();
+
+    return (
+      <Box display="grid" gap="10">
+        <RadioInput
+          name={`${groupId}-shipping`}
+          id={`${groupId}-standard`}
+          defaultChecked
+        >
+          Standard shipping
+        </RadioInput>
+        <RadioInput name={`${groupId}-shipping`} id={`${groupId}-express`}>
+          Express shipping
+        </RadioInput>
+      </Box>
+    );
+  },
+  parameters: {
+    controls: { disable: true },
   },
 };
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -11,12 +11,13 @@ import { Icon } from '../Icon';
 
 export type RadioProps = Omit<
   BoxProps,
-  'checked' | 'onChange' | keyof RadioVariantProps
+  'checked' | 'defaultChecked' | 'onChange' | keyof RadioVariantProps
 > &
   RadioVariantProps & {
-    name: string;
-    checked: boolean;
-    onChange: RadioChangeHandler;
+    name?: string;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onChange?: RadioChangeHandler;
     id?: string;
     error?: boolean;
     invalid?: boolean;
@@ -38,21 +39,21 @@ export type RadioChangeEvent = ChangeEvent<HTMLInputElement>;
 export type RadioChangeHandler = (e: RadioChangeEvent) => void;
 
 /**
- * Radio is a controlled component.
- * You must pass `checked` and `onChange` props.
+ * Radio supports both controlled and uncontrolled usage.
+ *
+ * @example
+ * <Radio defaultChecked />
  *
  * @example
  * const [checked, setChecked] = useState(false);
- * <Radio
- *   checked={checked}
- *   onChange={(e) => setChecked(e.target.checked)}
- * />
+ * <Radio checked={checked} onChange={(e) => setChecked(e.target.checked)} />
  */
 export const Radio = (props: RadioProps) => {
   const fieldContext = useFieldContext();
   const {
     name,
     checked,
+    defaultChecked,
     onChange,
     id,
     error: errorProp,
@@ -74,9 +75,7 @@ export const Radio = (props: RadioProps) => {
     indicator,
     radioBg,
   });
-
-  // Determine which icon to render based on state
-  const iconName = checked ? 'radio-checked' : 'radio';
+  const isControlled = checked !== undefined;
 
   return (
     <Box
@@ -90,16 +89,19 @@ export const Radio = (props: RadioProps) => {
         className={classes.input}
         name={name}
         id={id}
-        checked={checked}
+        {...(isControlled
+          ? { checked }
+          : { defaultChecked: defaultChecked ?? false })}
         onChange={onChange}
         disabled={disabled}
         {...(error && { 'data-error': true })}
         {...(invalid && { 'data-invalid': true, 'aria-invalid': true })}
         {...otherProps}
       />
-      <Icon className={classes.radioBg} name="circle" />
-      <Icon className={classes.indicator} name={iconName} />
-      <Icon className={classes.indicator} name="radio-focus" />
+      <Icon className={classes.radioBg} name="circle" aria-hidden />
+      <Icon className={classes.indicator} name="radio" aria-hidden />
+      <Icon className={classes.indicator} name="radio-checked" aria-hidden />
+      <Icon className={classes.indicator} name="radio-focus" aria-hidden />
     </Box>
   );
 };

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -1,0 +1,66 @@
+import { useState, type ReactNode } from 'react';
+
+import { Box, type BoxProps } from '../Box';
+
+import { RadioGroupContext } from './RadioGroupContext';
+
+export type RadioGroupProps = Omit<BoxProps, 'children' | 'role'> & {
+  name: string;
+  value?: string | null;
+  defaultValue?: string | null;
+  onChange?: (value: string) => void;
+  children: ReactNode;
+  label?: string;
+  id?: string;
+  disabled?: boolean;
+};
+
+export const RadioGroup = (props: RadioGroupProps) => {
+  const {
+    name,
+    value,
+    defaultValue = null,
+    onChange,
+    children,
+    label,
+    id,
+    disabled,
+    ...rest
+  } = props;
+
+  const [uncontrolledValue, setUncontrolledValue] = useState<string | null>(
+    defaultValue,
+  );
+  const isControlled = value !== undefined;
+  const selectedValue = isControlled ? value : uncontrolledValue;
+
+  const setSelectedValue = (nextValue: string) => {
+    if (!isControlled) {
+      setUncontrolledValue(nextValue);
+    }
+
+    onChange?.(nextValue);
+  };
+
+  return (
+    <RadioGroupContext.Provider
+      value={{
+        name,
+        value: selectedValue,
+        setValue: setSelectedValue,
+        disabled,
+      }}
+    >
+      <Box
+        role="radiogroup"
+        aria-label={label}
+        aria-labelledby={id ? `${id}-label` : undefined}
+        id={id}
+        aria-disabled={disabled}
+        {...rest}
+      >
+        {children}
+      </Box>
+    </RadioGroupContext.Provider>
+  );
+};

--- a/src/components/Radio/RadioGroupContext.ts
+++ b/src/components/Radio/RadioGroupContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export type RadioGroupContextValue = {
+  name: string;
+  value: string | null;
+  setValue: (value: string) => void;
+  disabled?: boolean;
+};
+
+export const RadioGroupContext = createContext<RadioGroupContextValue | null>(
+  null,
+);
+
+export const useRadioGroup = () => {
+  return useContext(RadioGroupContext);
+};

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,1 +1,3 @@
 export { Radio, type RadioProps, type RadioChangeHandler } from './Radio';
+export { RadioGroup, type RadioGroupProps } from './RadioGroup';
+export type { RadioGroupContextValue } from './RadioGroupContext';

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -12,14 +12,17 @@ import { splitProps } from '~/utils/splitProps';
 import { type BoxProps } from '../Box';
 import { Label } from '../Label';
 import { Radio } from '../Radio';
+import { useRadioGroup } from '../Radio/RadioGroupContext';
 
 import type { RadioChangeHandler } from '../Radio';
 
 export type RadioInputProps = Omit<BoxProps, keyof RadioInputVariantProps> &
   RadioInputVariantProps & {
-    name: string;
-    checked: boolean;
-    onChange: RadioChangeHandler;
+    name?: string;
+    value?: string;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onChange?: RadioChangeHandler;
     id?: string;
     error?: boolean;
     invalid?: boolean;
@@ -31,7 +34,9 @@ export const RadioInput = (props: RadioInputProps) => {
   const fieldContext = useFieldContext();
   const {
     name,
+    value,
     checked,
+    defaultChecked,
     onChange,
     id,
     children,
@@ -40,12 +45,27 @@ export const RadioInput = (props: RadioInputProps) => {
     disabled: disabledProp,
     ...rest
   } = props;
+  const radioGroup = useRadioGroup();
   const error = errorProp ?? fieldContext?.error;
   const invalid = invalidProp ?? fieldContext?.invalid;
-  const disabled = disabledProp ?? fieldContext?.disabled;
+  const disabled =
+    disabledProp ?? radioGroup?.disabled ?? fieldContext?.disabled;
   const [className, otherProps] = splitProps(rest);
   const generatedId = useId();
   const resolvedId = id ?? generatedId;
+  const resolvedName = radioGroup?.name ?? name;
+  const isGrouped = Boolean(radioGroup && value !== undefined);
+  const resolvedChecked =
+    isGrouped && radioGroup ? radioGroup.value === value : checked;
+
+  const handleChange: RadioChangeHandler | undefined = (event) => {
+    if (isGrouped && value !== undefined && radioGroup) {
+      radioGroup.setValue(value);
+    }
+
+    onChange?.(event);
+  };
+
   return (
     <Label
       className={cx(radioInput(), className)}
@@ -54,9 +74,10 @@ export const RadioInput = (props: RadioInputProps) => {
       {...otherProps}
     >
       <Radio
-        name={name}
-        checked={checked}
-        onChange={onChange}
+        name={resolvedName}
+        checked={resolvedChecked}
+        defaultChecked={!isGrouped ? defaultChecked : undefined}
+        onChange={handleChange}
         id={resolvedId}
         error={error}
         invalid={invalid}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Custom listbox-style select for controlled single and multi-select flows. Use with `FormField` for labels, help text, and error messaging.',
+          'Custom listbox-style select for controlled and uncontrolled single and multi-select flows. Use with `FormField` for labels, help text, and error messaging.',
       },
     },
   },
@@ -78,6 +78,22 @@ export const Default: Story = {
         </Select>
       </Box>
     );
+  },
+};
+
+export const Uncontrolled: Story = {
+  name: 'Uncontrolled',
+  render: () => (
+    <Box w="xs">
+      <Select defaultValue="growth" placeholder="Choose an option...">
+        <SelectOption value="starter" label="Starter" />
+        <SelectOption value="growth" label="Growth" />
+        <SelectOption value="enterprise" label="Enterprise" />
+      </Select>
+    </Box>
+  ),
+  parameters: {
+    controls: { disable: true },
   },
 };
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -131,10 +131,12 @@ export type SelectProps = Omit<
 > &
   SelectVariantProps & {
     value?: SelectValue;
+    defaultValue?: SelectValue;
     onChange?: (value: SelectValue) => void;
     multiple?: boolean;
     placeholder?: string;
     open?: boolean;
+    defaultOpen?: boolean;
     onOpenChange?: (open: boolean) => void;
     placement?: Placement;
     offset?: number;
@@ -150,10 +152,12 @@ export type SelectProps = Omit<
 export const Select = (props: SelectProps) => {
   const {
     value: controlledValue,
+    defaultValue = null,
     onChange,
     multiple = false,
     placeholder = 'Select...',
     open: controlledOpen,
+    defaultOpen = false,
     onOpenChange,
     placement = 'bottom-start',
     offset = 4,
@@ -174,8 +178,8 @@ export const Select = (props: SelectProps) => {
   const labelId = `${triggerId}-label`;
   const listboxId = `${triggerId}-listbox`;
 
-  const [internalOpen, setInternalOpen] = useState(false);
-  const [internalValue, setInternalValue] = useState<SelectValue>(null);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const [internalValue, setInternalValue] = useState<SelectValue>(defaultValue);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   const isOpenControlled = controlledOpen !== undefined;

--- a/src/components/TimePicker/TimePicker.stories.tsx
+++ b/src/components/TimePicker/TimePicker.stories.tsx
@@ -70,6 +70,13 @@ export const WithValue: Story = {
   ),
 };
 
+export const WithDefaultValue: Story = {
+  name: 'With Default Value',
+  render: () => (
+    <TimePicker hourCycle="12" defaultValue={{ hour: 14, minute: 30 }} />
+  ),
+};
+
 export const MinuteStep15: Story = {
   name: 'Minute Step: 15',
   render: () => (

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -256,6 +256,8 @@ export type TimePickerProps = Omit<
   TimePickerVariantProps & {
     /** Controlled value — hour is always 24h (0–23) internally */
     value?: TimeValue | null;
+    /** Initial uncontrolled value — hour is always 24h (0–23) internally */
+    defaultValue?: TimeValue | null;
     /** Called when the time changes */
     onChange?: (value: TimeValue | null) => void;
     /** 12-hour or 24-hour display */
@@ -271,6 +273,8 @@ export type TimePickerProps = Omit<
     name?: string;
     /** Controlled popover open state */
     open?: boolean;
+    /** Initial uncontrolled popover state */
+    defaultOpen?: boolean;
     onOpenChange?: (open: boolean) => void;
     size?: TimePickerVariantProps['size'];
   };
@@ -281,6 +285,7 @@ export const TimePicker = (props: TimePickerProps) => {
   const fieldContext = useFieldContext();
   const {
     value,
+    defaultValue = null,
     onChange,
     hourCycle = '12',
     minuteStep = 1,
@@ -290,6 +295,7 @@ export const TimePicker = (props: TimePickerProps) => {
     invalid: invalidProp,
     size: sizeProp,
     open: controlledOpen,
+    defaultOpen = false,
     onOpenChange,
     ...rest
   } = props;
@@ -299,6 +305,7 @@ export const TimePicker = (props: TimePickerProps) => {
   const size = sizeProp ?? fieldContext?.size;
 
   const [className, otherProps] = splitProps(rest);
+  const initialValue = value !== undefined ? value : defaultValue;
 
   const segments = getSegments(hourCycle);
 
@@ -323,19 +330,21 @@ export const TimePicker = (props: TimePickerProps) => {
   );
 
   const [numericVals, setNumericVals] = useState<NumericValues>(() =>
-    initNumericValues(value),
+    initNumericValues(initialValue),
   );
   const [rawInput, setRawInput] = useState<NumericRaw>({
     hour: '',
     minute: '',
   });
-  const [ampm, setAmpm] = useState<'AM' | 'PM' | null>(() => initAmpm(value));
+  const [ampm, setAmpm] = useState<'AM' | 'PM' | null>(() =>
+    initAmpm(initialValue),
+  );
   const [_focusedSegment, setFocusedSegment] = useState<SegmentType | null>(
     null,
   );
 
   // ── Popover state ──────────────────────────────────────────────────────────
-  const [internalOpen, setInternalOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
   const isOpen = controlledOpen ?? internalOpen;
 
   const handleOpenChange = useCallback(

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Use `ToggleInput` in product settings and forms so label association and spacing are consistent. Use `Toggle` when composing custom wrappers only.',
+          'Use `ToggleInput` in product settings and forms so label association and spacing are consistent. Use `Toggle` when composing custom wrappers only. Both controlled and uncontrolled usage are supported.',
       },
     },
   },
@@ -63,6 +63,22 @@ export const Default: Story = {
           'Recommended default for app settings: controlled `ToggleInput` with clear label text.',
       },
     },
+  },
+};
+
+export const Uncontrolled: Story = {
+  name: 'Uncontrolled',
+  render: () => (
+    <ToggleInput
+      name="uncontrolled-toggle"
+      id="uncontrolled-toggle"
+      defaultChecked
+    >
+      Enable compact mode
+    </ToggleInput>
+  ),
+  parameters: {
+    controls: { disable: true },
   },
 };
 

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -11,12 +11,13 @@ import { Icon } from '../Icon';
 
 export type ToggleProps = Omit<
   BoxProps,
-  'checked' | 'onChange' | keyof ToggleVariantProps
+  'checked' | 'defaultChecked' | 'onChange' | keyof ToggleVariantProps
 > &
   ToggleVariantProps & {
     name: string;
-    checked: boolean;
-    onChange: ToggleChangeHandler;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onChange?: ToggleChangeHandler;
     id?: string;
     error?: boolean;
     invalid?: boolean;
@@ -38,15 +39,14 @@ export type ToggleChangeEvent = ChangeEvent<HTMLInputElement>;
 export type ToggleChangeHandler = (e: ToggleChangeEvent) => void;
 
 /**
- * Toggle is a controlled component.
- * You must pass `checked` and `onChange` props.
+ * Toggle supports both controlled and uncontrolled usage.
+ *
+ * @example
+ * <Toggle defaultChecked />
  *
  * @example
  * const [checked, setChecked] = useState(false);
- * <Toggle
- *   checked={checked}
- *   onChange={(e) => setChecked(e.target.checked)}
- * />
+ * <Toggle checked={checked} onChange={(e) => setChecked(e.target.checked)} />
  */
 
 export const Toggle = (props: ToggleProps) => {
@@ -54,6 +54,7 @@ export const Toggle = (props: ToggleProps) => {
   const {
     name,
     checked,
+    defaultChecked,
     onChange,
     id,
     error: errorProp,
@@ -73,9 +74,7 @@ export const Toggle = (props: ToggleProps) => {
     input,
     indicator,
   });
-
-  // Determine which icon to render based on state
-  const iconName = checked ? 'circle-check' : 'circle';
+  const isControlled = checked !== undefined;
 
   return (
     <Box
@@ -89,14 +88,17 @@ export const Toggle = (props: ToggleProps) => {
         className={classes.input}
         name={name}
         id={id}
-        checked={checked}
+        {...(isControlled
+          ? { checked }
+          : { defaultChecked: defaultChecked ?? false })}
         onChange={onChange}
         disabled={disabled}
         {...(error && { 'data-error': true })}
         {...(invalid && { 'data-invalid': true, 'aria-invalid': true })}
         {...otherProps}
       />
-      <Icon className={classes.indicator} name={iconName} />
+      <Icon className={classes.indicator} name="circle" aria-hidden />
+      <Icon className={classes.indicator} name="circle-check" aria-hidden />
     </Box>
   );
 };

--- a/src/components/ToggleInput/ToggleInput.tsx
+++ b/src/components/ToggleInput/ToggleInput.tsx
@@ -18,8 +18,9 @@ import type { ToggleChangeHandler } from '../Toggle';
 export type ToggleInputProps = Omit<BoxProps, keyof ToggleInputVariantProps> &
   ToggleInputVariantProps & {
     name: string;
-    checked: boolean;
-    onChange: ToggleChangeHandler;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onChange?: ToggleChangeHandler;
     id?: string;
     error?: boolean;
     invalid?: boolean;
@@ -32,6 +33,7 @@ export const ToggleInput = (props: ToggleInputProps) => {
   const {
     name,
     checked,
+    defaultChecked,
     onChange,
     id,
     children,
@@ -57,6 +59,7 @@ export const ToggleInput = (props: ToggleInputProps) => {
       <Toggle
         name={name}
         checked={checked}
+        defaultChecked={defaultChecked}
         onChange={onChange}
         id={resolvedId}
         error={error}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export {
   ModalBody,
   type useModalContext,
 } from './components/Modal';
-export { Radio } from './components/Radio';
+export { Radio, RadioGroup } from './components/Radio';
 export { RadioInput } from './components/RadioInput';
 export { Spinner } from './components/Spinner';
 export { Tag } from './components/Tag';

--- a/src/recipes/checkbox.ts
+++ b/src/recipes/checkbox.ts
@@ -27,6 +27,12 @@ export const checkboxRecipe = defineSlotRecipe({
         display: 'inline-grid',
         zIndex: '3',
       },
+      "& ~ [name='checkbox-checked']": {
+        display: 'none',
+      },
+      "& ~ [name='checkbox-indeterminate']": {
+        display: 'none',
+      },
       _checked: {
         "& ~ [name='checkbox-checked']": {
           display: 'inline-grid',
@@ -36,15 +42,20 @@ export const checkboxRecipe = defineSlotRecipe({
         "& ~ [name='checkbox']": {
           display: 'none',
         },
+        "& ~ [name='checkbox-indeterminate']": {
+          display: 'none',
+        },
       },
-      _indeterminate: {
+      '&[data-indeterminate]': {
         "& ~ [name='checkbox-indeterminate']": {
           display: 'inline-grid',
           fill: 'icon',
           zIndex: '3',
-          _disabled: {},
         },
         "& ~ [name='checkbox']": {
+          display: 'none',
+        },
+        "& ~ [name='checkbox-checked']": {
           display: 'none',
         },
       },

--- a/src/recipes/radio.ts
+++ b/src/recipes/radio.ts
@@ -32,6 +32,9 @@ export const radioRecipe = defineSlotRecipe({
         display: 'inline-grid',
         zIndex: 'zIndex.3',
       },
+      "& ~ [name='radio-checked']": {
+        display: 'none',
+      },
       _checked: {
         "& ~ [name='radio-checked']": {
           display: 'inline-grid',

--- a/src/storybook/docs/componentStandards.mdx
+++ b/src/storybook/docs/componentStandards.mdx
@@ -2,7 +2,6 @@ import { Meta, Unstyled } from '@storybook/blocks';
 import { Flex } from '@styled-system/jsx';
 import { Divider } from '~/components/Divider';
 import { Link } from '~/components/Link';
-import { Text } from '~/components/Text';
 
 <Meta title="Docs / Component Standards" />
 
@@ -19,14 +18,13 @@ This page is the short version: one rule, a brief reason, and a real example. Th
 Use <code>Omit&lt;BoxProps, keyof VariantProps&gt;</code> first, then add component-specific props. This keeps HTML props, `as`, and ref typing consistent.
 
 ```tsx
-export type ChipProps =
-  Omit<BoxProps, keyof ChipVariantProps> &
+export type ChipProps = Omit<BoxProps, keyof ChipVariantProps> &
   ChipVariantProps & {
-  // ...
-};
+    // ...
+  };
 ```
 
-Related: <Link href="/?path=/docs/docs-controlled-components-philosophy--documentation">Controlled Components Philosophy</Link>
+Related: <Link href="/?path=/docs/docs-controlled-and-uncontrolled-components-philosophy--documentation">Controlled and Uncontrolled Components Philosophy</Link>
 
 <Divider weight="thick" color="border.disabled" my="48" />
 
@@ -82,7 +80,7 @@ export const Avatar = (props: AvatarProps) => {
 };
 ```
 
-<Divider weight="thick" color="border.disabled" my="48"/>
+<Divider weight="thick" color="border.disabled" my="48" />
 
 ## 5. `onClick` does not need to be explicitly defined in the component's props.
 
@@ -117,10 +115,11 @@ export type ComponentProps = {
 For usual suspects like `size` and `variant`, derive the public prop type from `*VariantProps[...]` so responsive and conditional values remain accepted.
 
 ```tsx
-export type ButtonProps = Omit<BoxProps, keyof ButtonVariantProps> & ButtonVariantProps & {
-  variant?: ButtonVariantProps['variant'];
-  size?: ButtonVariantProps['size'];
-};
+export type ButtonProps = Omit<BoxProps, keyof ButtonVariantProps> &
+  ButtonVariantProps & {
+    variant?: ButtonVariantProps['variant'];
+    size?: ButtonVariantProps['size'];
+  };
 ```
 
 If you manually redefine `size` or `variant`, you are usually breaking conditional values.

--- a/src/storybook/docs/controlled-components-philosophy.mdx
+++ b/src/storybook/docs/controlled-components-philosophy.mdx
@@ -1,708 +1,131 @@
-import {
-  Meta,
-  Title,
-  Primary,
-  Controls,
-  Stories,
-  ArgTypes,
-  Canvas,
-  Unstyled
-} from '@storybook/blocks';
-import { Box } from '../../components/Box';
-import { Text } from '../../components/Text';
-import { Heading } from '../../components/Heading';
+import { Meta, Unstyled } from '@storybook/blocks';
 import { Divider } from '../../components/Divider';
-import { Flex, Wrap, Grid } from '@styled-system/jsx';
+import { Flex, Grid, Wrap } from '@styled-system/jsx';
+import { Text } from '../../components/Text';
 import '../../styles/font-imports.css';
 
-<Meta title="Docs / Controlled Components Philosophy" />
+<Meta title="Docs / Controlled and Uncontrolled Components Philosophy" />
 
 <Unstyled>
-
   <Flex flexDirection="column" gap="16">
-    # Controlled Components Philosophy
+    # Controlled and Uncontrolled Components Philosophy
 
-    This document explains why the Cetec Design System uses `controlled components` as the standard pattern for form inputs, including checkboxes, radios, text inputs, and other interactive elements.
+    The Cetec Design System supports both controlled and uncontrolled form APIs. Controlled props are still the default recommendation for complex app state, but several input families now expose native-friendly uncontrolled entrypoints so they work cleanly in static Astro pages and plain HTML forms.
 
     <Text as="blockquote" textStyle="body-lg" p="12" borderLeftWidth="4" borderLeftColor="slate.20" borderLeftStyle="solid" my="8" maxW="prose">
-      <i>Controlled components in React are highly beneficial because they treat the React state as the "single source of truth" for form data, which provides developers with explicit control over component behavior and data flow.</i>
+      <i>Use controlled state when the UI needs React to stay in the loop. Use uncontrolled state when the browser can own the value and the component should still render correctly without hydration.</i>
     </Text>
 
-    <Divider my="16"/>
+    <Divider my="16" />
 
-    ## What's the Difference
+    ## What The System Supports
 
     <Wrap gap="24">
-      <Flex flexDirection="column">
-        #### Controlled Component
+      <Flex flexDirection="column" gap="8">
+        #### Controlled
 
-        Components where the parent explicitly controls the state:
-
-        ```typescript
-        // Parent controls the state explicitly
-        const [isChecked, setIsChecked] = useState(false);
-
-        <Checkbox
-          name="terms"
-          checked={isChecked}
-          onChange={(e) => setIsChecked(e.target.checked)}
-        />
-        ```
+        - Parent owns the current value.
+        - Use `checked` / `value` plus `onChange`.
+        - Best for validation, cross-field logic, analytics, and derived UI.
+        - Still the default for overlays and pickers when app state needs to be explicit.
       </Flex>
 
-      <Flex flexDirection="column">
-        #### Uncontrolled Component
+      <Flex flexDirection="column" gap="8">
+        #### Uncontrolled
 
-        Components that manage their own internal state:
-
-        ```typescript
-        // Component manages its own state internally
-        <Checkbox name="terms" onChange={handleChange} />
-        // User doesn't control checked state - component does
-        ```
+        - The browser owns the initial and current value.
+        - Use `defaultChecked` / `defaultValue` for the starting state.
+        - Best for static forms, Astro islands you want to avoid, and native form submission.
+        - Works well when the component does not need to drive other UI state.
       </Flex>
     </Wrap>
 
-    <Divider my="16"/>
+    <Divider my="16" />
 
-    ## Why Controlled Components for Design Systems
+    ## Component Families
 
-    ### 1. Predictability & Debugging
+    <Grid columns={{ base: 1, md: 2 }} gap="24">
+      <Flex flexDirection="column" gap="8">
+        #### Native Inputs
 
-    <Grid columns={2} gap="24">
-      <Flex flexDirection="column">
-        #### Controlled
+        `TextInput` and `Textarea` already follow native HTML behavior. Use `defaultValue` when the browser should own the field and `value` when React should own it.
 
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">State is explicit and visible in parent component</Box>
-          <Box as="li" listStyleType="disc">Easy to debug: "What's the checkbox state?" → Look at the state variable</Box>
-          <Box as="li" listStyleType="disc">No hidden internal state</Box>
-          <Box as="li" listStyleType="disc">Single source of truth</Box>
-        </Box>
-      </Flex>
-
-
-      <Flex flexDirection="column">
-        #### Uncontrolled
-
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">State hidden inside component</Box>
-          <Box as="li" listStyleType="disc">Harder to debug: "Why is this checked?" → Need to inspect DOM or component internals</Box>
-          <Box as="li" listStyleType="disc">Multiple sources of truth</Box>
-          <Box as="li" listStyleType="disc">Requires refs and imperative APIs</Box>
-        </Box>
-      </Flex>
-    </Grid>
-
-    <Box py="8" px="16" bg="warning.lighter" color="warning.dark" borderRadius="4" width="fit-content"><b>Design System Goal:</b> Components should be predictable and transparent.</Box>
-
-    <Flex flexDirection="column">
-      Example:
-
-      ```typescript
-      // Controlled - clear state visibility
-      const [accepted, setAccepted] = useState(false);
-      console.log('Terms accepted:', accepted); // Always accurate
-
-      <Checkbox checked={accepted} onChange={e => setAccepted(e.target.checked)} />
-      ```
-    </Flex>
-
-    <Divider my="16"/>
-
-    ### 2. Composability & Integration
-
-    Design systems are building blocks that integrate with:
-
-    <Box as="ul" gap="8" pl="24">
-      <Box as="li" listStyleType="disc">Form libraries (React Hook Form, Formik, Final Form)</Box>
-      <Box as="li" listStyleType="disc">State management (Redux, Zustand, Context API)</Box>
-      <Box as="li" listStyleType="disc">URL state synchronization</Box>
-      <Box as="li" listStyleType="disc">Local storage persistence</Box>
-      <Box as="li" listStyleType="disc">Real-time collaboration</Box>
-    </Box>
-
-    <Grid columns={2} gap="24">
-      <Flex flexDirection="column">
-        #### Controlled
-        Controlled components integrate seamlessly:
-
-        ```typescript
-        // React Hook Form
-        const { register, watch } = useForm();
-        const terms = watch('terms');
-
-        <Checkbox
-          {...register('terms')}
-          checked={terms}
-        />
-
-        // Redux
-        <Checkbox
-          checked={termsAccepted}
-          onChange={() => dispatch(toggleTerms())}
-        />
-
-        // URL state sync
-        const [searchParams, setSearchParams] = useSearchParams();
-        <Checkbox
-          checked={searchParams.get('filter') === 'active'}
-          onChange={e => setSearchParams({ filter: e.target.checked ? 'active' : 'all' })}
-        />
+        ```tsx
+        <TextInput name="email" defaultValue="hello@cetec.com" />
+        <Textarea name="notes" defaultValue="Draft notes" />
         ```
       </Flex>
 
-      <Flex flexDirection="column">
-        #### Uncontrolled
-        Uncontrolled components fight these patterns:
-        ```typescript
-        // Need refs and imperative APIs - messy and error-prone
-        const checkboxRef = useRef();
-        // Then manually sync state... defeats the purpose
-        ```
-      </Flex>
-    </Grid>
+      <Flex flexDirection="column" gap="8">
+        #### Binary Controls
 
-    <Box py="8" px="16" bg="warning.lighter" color="warning.dark" borderRadius="4" width="fit-content"><b>Design System Goal:</b> Work seamlessly with the ecosystem.</Box>
+        `Checkbox`, `Toggle`, and `Radio` support both controlled and uncontrolled usage. Their visual state follows the native input state, which keeps static renders correct without hydration.
 
-    <Divider my="16"/>
+        `RadioGroup` handles grouped radio selection. Use it instead of treating radios as unrelated toggles.
 
-    ### 3. Derived State & Validation
-
-    <Flex flexDirection="column">
-      Real applications need checkbox state to derive other UI:
-
-    ```typescript
-    const [terms, setTerms] = useState(false);
-    const [privacy, setPrivacy] = useState(false);
-    const [marketing, setMarketing] = useState(false);
-
-    // Derived state is trivial with controlled components
-    const canSubmit = terms && privacy;
-    const allSelected = terms && privacy && marketing;
-    const someSelected = terms || privacy || marketing;
-
-    return (
-      <>
-        <Checkbox
-          checked={terms}
-          onChange={e => setTerms(e.target.checked)}
-          error={!terms}
-        >
-          Accept terms (required)
+        ```tsx
+        <Checkbox name="terms" defaultChecked>
+          Accept terms
         </Checkbox>
-
-        <Checkbox
-          checked={privacy}
-          onChange={e => setPrivacy(e.target.checked)}
-          error={!privacy}
-        >
-          Accept privacy policy (required)
-        </Checkbox>
-
-        <Checkbox
-          checked={marketing}
-          onChange={e => setMarketing(e.target.checked)}
-        >
-          Marketing emails (optional)
-        </Checkbox>
-
-        <Button disabled={!canSubmit}>Submit</Button>
-
-        {allSelected && <Text>Thanks for accepting everything!</Text>}
-      </>
-    );
-    ```
-    </Flex>
-    <Flex flexDirection="column">
-      With uncontrolled components:
-      <Box as="ul" gap="8" pl="24">
-        <Box as="li" listStyleType="disc">Query DOM on every state check (expensive)</Box>
-        <Box as="li" listStyleType="disc">Or maintain parallel state anyway (defeats purpose)</Box>
-        <Box as="li" listStyleType="disc">Can't derive state reliably</Box>
-      </Box>
-    </Flex>
-
-    <Box py="8" px="16" bg="warning.lighter" color="warning.dark" borderRadius="4" width="fit-content"><b>Design System Goal:</b> Support real-world application patterns.</Box>
-
-    <Divider my="16"/>
-
-    ### 4. Testing & Documentation
-
-    <Grid columns={2} gap="24">
-      <Flex flexDirection="column">
-      #### Controlled
-        Controlled components are easier to test:
-
-        ```typescript
-        // Set up exact state - no user interaction needed
-        render(
-          <Checkbox
-            checked={true}
-            onChange={mockFn}
-          />
-        );
-
-        // Assert on state
-        expect(screen.getByRole('checkbox')).toBeChecked();
-
-        // Test state changes
-        fireEvent.click(screen.getByRole('checkbox'));
-        expect(mockFn).toHaveBeenCalledWith(expect.objectContaining({
-          target: expect.objectContaining({ checked: false })
-        }));
         ```
       </Flex>
-      <Flex flexDirection="column">
-      #### Uncontrolled
-        Uncontrolled components require:
 
-        ```typescript
-        // Must simulate user interaction
-        userEvent.click(screen.getByRole('checkbox'));
-        // Hope internal state updated correctly
-        // Can't set up specific states without clicking
+      <Flex flexDirection="column" gap="8">
+        #### Composite Controls
+
+        `Select`, `DatePicker`, `TimePicker`, and `ChipGroup` expose controlled and uncontrolled entrypoints too. They are still JS-driven widgets, so the API is friendlier, but the interaction model still needs hydration.
+
+        ```tsx
+        <Select defaultValue="growth" placeholder="Choose an option..." />
+        <ChipGroup type="single" defaultValue="growth" label="Plan size" />
         ```
       </Flex>
-    </Grid>
 
-    <Flex flexDirection="column">
-      Storybook benefits:
+      <Flex flexDirection="column" gap="8">
+        #### Shared Context
 
-    ```typescript
-    // Controlled - can show every state combination
-    export const AllStates: Story = {
-      render: () => (
-        <>
-          <Checkbox checked={false} onChange={noop} />
-          <Checkbox checked={true} onChange={noop} />
-          <Checkbox checked={false} indeterminate onChange={noop} />
-          <Checkbox checked={true} error onChange={noop} />
-          <Checkbox checked={true} disabled onChange={noop} />
-        </>
-      )
-    };
-    ```
-    </Flex>
+        Shared context should stay focused on layout and group semantics. Do not push generic field state into `FieldContext` or `SlotContext`.
 
-    <Box py="8" px="16" bg="warning.lighter" color="warning.dark" borderRadius="4" width="fit-content"><b>Design System Goal:</b> Easy to document, test, and demonstrate.</Box>
-
-    <Divider my="16"/>
-
-    ### 5. React Philosophy & Future
-
-    <Flex flexDirection="column" gap="8">
-      React's mental model strongly favors controlled components:
-
-      <Grid columns={3} gap="16">
-        <Flex flexDirection="column">
-          **One-way data flow:**
-          <Box as="ul" gap="8" pl="24">
-            <Box as="li" listStyleType="disc">Props flow down</Box>
-            <Box as="li" listStyleType="disc">Events flow up</Box>
-            <Box as="li" listStyleType="disc">Clear, unidirectional data path</Box>
-          </Box>
-        </Flex>
-
-        <Flex flexDirection="column">
-          **Declarative UI:**
-          <Box as="ul" gap="8" pl="24">
-            <Box as="li" listStyleType="disc">UI is a function of state</Box>
-            <Box as="li" listStyleType="disc">`UI = f(state)`</Box>
-            <Box as="li" listStyleType="disc">State changes trigger re-renders</Box>
-          </Box>
-        </Flex>
-
-        <Flex flexDirection="column">
-          **React Server Components:**
-          <Box as="ul" gap="8" pl="24">
-            <Box as="li" listStyleType="disc">Uncontrolled components don't work in RSC patterns</Box>
-            <Box as="li" listStyleType="disc">Server components can't manage client state</Box>
-            <Box as="li" listStyleType="disc">Controlled pattern is future-proof</Box>
-          </Box>
-        </Flex>
-      </Grid>
-
-      <Flex flexDirection="column">
-        **From React documentation:**
-        <Text as="blockquote" textStyle="body-lg" p="12" borderLeftWidth="4" borderLeftColor="slate.20" borderLeftStyle="solid" my="8" maxW="prose">
-          <i>"We recommend using controlled components to implement forms. In a controlled component, form data is handled by a React component."</i>
-        </Text>
-      </Flex>
-
-      <Box py="8" px="16" bg="warning.lighter" color="warning.dark" borderRadius="4" width="fit-content"><b>Design System Goal:</b> Align with framework best practices and future direction.</Box>
-    </Flex>
-
-    <Divider my="16"/>
-
-    ## When Uncontrolled Makes Sense
-
-
-    <Grid columns={2} gap="24" alignItems="center">
-      <Flex flexDirection="column">
-      #### Traditional Form Submission
-        If using native HTML form posts (not SPA patterns) that post directly to a server without JavaScript interaction.
-      </Flex>
-
-      ```html
-      <form action="/submit" method="POST">
-        <input type="checkbox" name="terms" />
-        <button type="submit">Submit</button>
-      </form>
-      ```
-
-      <Flex flexDirection="column">
-      #### Quick Prototypes
-        When prototyping and you genuinely don't need to access the state:
-      </Flex>
-
-      ```typescript
-      // Throwaway code for testing
-        <Checkbox name="temp" />
-      ```
-
-      <Flex flexDirection="column">
-      #### Legacy Codebases
-        When integrating with legacy systems that expect uncontrolled inputs.
+        Use a dedicated group context where a component actually owns coordinated selection, like `RadioGroup` or `ChipGroup`.
       </Flex>
     </Grid>
 
-    <Divider my="16"/>
+    <Divider my="16" />
 
-    ## The Trade-off
+    ## When To Use Which Mode
 
-    ### Verbosity
+    <Grid columns={{ base: 1, md: 2 }} gap="24">
+      <Flex flexDirection="column" gap="8">
+        #### Prefer Controlled When
 
-    <Grid columns={2} gap="24">
-      <Flex flexDirection="column">
-      #### Controlled
-        Controlled requires boilerplate:
-        ```typescript
-        const [checked, setChecked] = useState(false);
-        <Checkbox checked={checked} onChange={e => setChecked(e.target.checked)} />
-        ```
-      </Flex>
-      <Flex flexDirection="column">
-      #### Uncontrolled
-        Uncontrolled is shorter:
-        ```typescript
-        <Checkbox name="terms" />
-        ```
-      </Flex>
-    </Grid>
-
-    ### But Consider
-
-    In real applications, you almost always need that state anyway for:
-    <Box as="ul" gap="8" pl="24">
-      <Box as="li" listStyleType="disc">Form validation</Box>
-      <Box as="li" listStyleType="disc">Submit button enable/disable</Box>
-      <Box as="li" listStyleType="disc">Conditional rendering</Box>
-      <Box as="li" listStyleType="disc">Success/error messages</Box>
-      <Box as="li" listStyleType="disc">Analytics tracking</Box>
-    </Box>
-
-    So the "extra" boilerplate is just making explicit what you'd need regardless.
-
-    <Divider my="16"/>
-
-    ## Implementation Options Considered
-
-    ### Option A: Controlled Only (Chosen)
-
-    ```typescript
-    type CheckboxProps = {
-      checked: boolean;      // Required!
-      onChange: ChangeEventHandler<HTMLInputElement>; // Required!
-      name: string;
-      // ...
-    };
-    ```
-
-    <Grid gridTemplateColumns="auto auto" gap="24" w="fit">
-      <Flex flexDirection="column" w="fit">
-        **Pros**
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">Explicit contract</Box>
-          <Box as="li" listStyleType="disc">No hidden state</Box>
-          <Box as="li" listStyleType="disc">Forces best practices</Box>
-          <Box as="li" listStyleType="disc">Simpler component code</Box>
-          <Box as="li" listStyleType="disc">Clear documentation</Box>
-        </Box>
+        - The checked or selected state drives other UI.
+        - Validation depends on the latest value.
+        - You need to sync state with URL params, stores, or analytics.
+        - You are already in a React island and state is part of the app model.
       </Flex>
 
-      <Flex flexDirection="column" w="fit">
-        **Cons**
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">More verbose for consumers</Box>
-          <Box as="li" listStyleType="disc">Can't use without state management</Box>
-        </Box>
+      <Flex flexDirection="column" gap="8">
+        #### Prefer Uncontrolled When
+
+        - The browser can own the value safely.
+        - The page is static or lightly interactive.
+        - You want native form submission without extra glue code.
+        - The component is only serving as a local input and does not gate other UI.
       </Flex>
     </Grid>
 
-    <Divider my="16"/>
+    <Divider my="16" />
 
-    ### Option B: Controlled with Smart Defaults
+    ## Documentation Rule Of Thumb
 
-    ```typescript
-    type CheckboxProps = {
-      checked?: boolean;
-      defaultChecked?: boolean;  // Initial uncontrolled state
-      onChange?: ChangeEventHandler<HTMLInputElement>;
-      // ...
-    };
+    Every form component doc should say:
 
-    // Component manages both modes
-    const isControlled = checked !== undefined;
-    const [internalChecked, setInternalChecked] = useState(defaultChecked ?? false);
-    const actualChecked = isControlled ? checked : internalChecked;
-    ```
+    - whether the component is controlled, uncontrolled, or dual-mode
+    - which props are the controlled props
+    - which props initialize uncontrolled state
+    - whether the control needs hydration for interaction
 
-    <Grid gridTemplateColumns="auto auto" gap="24" w="fit">
-      <Flex flexDirection="column">
-        **Pros**
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">Supports both patterns</Box>
-          <Box as="li" listStyleType="disc">Flexible for edge cases</Box>
-          <Box as="li" listStyleType="disc">Better DX for simple use cases</Box>
-        </Box>
-      </Flex>
-
-      <Flex flexDirection="column">
-        **Cons**
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">More complex component code</Box>
-          <Box as="li" listStyleType="disc">Can encourage anti-patterns</Box>
-          <Box as="li" listStyleType="disc">Needs careful documentation about which mode you're in</Box>
-          <Box as="li" listStyleType="disc">Dual-mode bugs harder to debug</Box>
-        </Box>
-      </Flex>
-    </Grid>
-
-    Verdict: ❌ Too complex, enables anti-patterns
-
-    <Divider my="16"/>
-
-    ### Option C: Controlled Only + Helper Hook
-
-    ```typescript
-    // Design system exports helper
-    export function useCheckbox(defaultChecked = false) {
-      const [checked, setChecked] = useState(defaultChecked);
-      const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-        setChecked(e.target.checked);
-      };
-      return { checked, onChange };
-    }
-
-    // Consumer usage - still controlled but less boilerplate
-    const termsCheckbox = useCheckbox();
-    <Checkbox {...termsCheckbox} name="terms" />
-    ```
-
-    <Grid gridTemplateColumns="auto auto" gap="24" w="fit">
-      <Flex flexDirection="column">
-        **Pros**
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">Maintains controlled pattern</Box>
-          <Box as="li" listStyleType="disc">Reduces boilerplate</Box>
-          <Box as="li" listStyleType="disc">Encourages best practices</Box>
-          <Box as="li" listStyleType="disc">Easy to extend with validation</Box>
-        </Box>
-      </Flex>
-      <Flex flexDirection="column">
-        **Cons**
-        <Box as="ul" gap="8" pl="24">
-          <Box as="li" listStyleType="disc">One more concept to learn</Box>
-          <Box as="li" listStyleType="disc">Still need the hook import</Box>
-        </Box>
-      </Flex>
-    </Grid>
-
-    Verdict: ✅ Good future enhancement
-
-    <Divider my="16"/>
-
-    ### Why Controlled Components Are Right for Cetec:
-
-    <Box as="ol" gap="8" pl="24">
-      <Box as="li" listStyleType="decimal">**Target audience:** Developers building complex enterprise ERP applications</Box>
-      <Box as="li" listStyleType="decimal">**Integration needs:** Must work with forms, validation, complex state management</Box>
-      <Box as="li" listStyleType="decimal">**Documentation:** Storybook already demonstrates controlled patterns</Box>
-      <Box as="li" listStyleType="decimal">**Simplicity:** Simpler component internals (no dual-mode complexity)</Box>
-      <Box as="li" listStyleType="decimal">**Standards alignment:** Follows React team recommendations</Box>
-      <Box as="li" listStyleType="decimal">**Testing:** Easier to test and debug</Box>
-      <Box as="li" listStyleType="decimal">**Future-proof:** Compatible with React Server Components</Box>
-    </Box>
-
-    ### Documentation Approach
-
-    All controlled components should clearly document:
-
-    ```typescript
-    /**
-     * Checkbox is a controlled component.
-    * You must pass `checked` and `onChange` props.
-    *
-    * @example
-    * ```tsx
-    * const [checked, setChecked] = useState(false);
-    *
-    * <Checkbox
-    *   name="terms"
-    *   checked={checked}
-    *   onChange={(e) => setChecked(e.target.checked)}
-    * >
-    *   I accept the terms
-    * </Checkbox>
-    * ```
-    */
-    ```
-
-    <Divider my="16"/>
-
-    ## Real-World Examples
-
-    #### Simple Form
-
-    ```typescript
-    function NewsletterSignup() {
-      const [email, setEmail] = useState('');
-      const [consent, setConsent] = useState(false);
-
-      const handleSubmit = (e) => {
-        e.preventDefault();
-        if (consent) {
-          subscribe(email);
-        }
-      };
-
-      return (
-        <form onSubmit={handleSubmit}>
-          <TextInput
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-          />
-          <Checkbox
-            checked={consent}
-            onChange={e => setConsent(e.target.checked)}
-          >
-            I consent to receive emails
-          </Checkbox>
-          <Button type="submit" disabled={!consent}>
-            Sign Up
-          </Button>
-        </form>
-      );
-    }
-    ```
-
-    #### Select All Pattern
-
-    ```typescript
-    function TaskList() {
-      const [tasks, setTasks] = useState([
-        { id: 1, name: 'Task 1', completed: false },
-        { id: 2, name: 'Task 2', completed: true },
-        { id: 3, name: 'Task 3', completed: false },
-      ]);
-
-      const allCompleted = tasks.every(t => t.completed);
-      const someCompleted = tasks.some(t => t.completed) && !allCompleted;
-
-      const handleSelectAll = (checked) => {
-        setTasks(tasks.map(t => ({ ...t, completed: checked })));
-      };
-
-      const handleToggle = (id, checked) => {
-        setTasks(tasks.map(t =>
-          t.id === id ? { ...t, completed: checked } : t
-        ));
-      };
-
-      return (
-        <>
-          <Checkbox
-            checked={allCompleted}
-            indeterminate={someCompleted}
-            onChange={e => handleSelectAll(e.target.checked)}
-          >
-            Select All
-          </Checkbox>
-
-          {tasks.map(task => (
-            <Checkbox
-              key={task.id}
-              checked={task.completed}
-              onChange={e => handleToggle(task.id, e.target.checked)}
-            >
-              {task.name}
-            </Checkbox>
-          ))}
-        </>
-      );
-    }
-    ```
-
-    #### Form Library Integration
-
-    ```typescript
-    import { useForm } from 'react-hook-form';
-
-    function RegistrationForm() {
-      const { register, watch, handleSubmit } = useForm();
-      const terms = watch('terms');
-      const privacy = watch('privacy');
-
-      const onSubmit = (data) => {
-        console.log(data);
-      };
-
-      return (
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <Checkbox
-            {...register('terms', { required: true })}
-            checked={terms}
-          >
-            I accept the terms
-          </Checkbox>
-
-          <Checkbox
-            {...register('privacy', { required: true })}
-            checked={privacy}
-          >
-            I accept the privacy policy
-          </Checkbox>
-
-          <Button type="submit" disabled={!terms || !privacy}>
-            Register
-          </Button>
-        </form>
-      );
-    }
-    ```
-
-    <Divider my="16"/>
-
-    ## Summary
-
-    The controlled component pattern is the right choice for the Cetec Design System because:
-
-    <Box as="ol" gap="8" pl="24">
-      <Box as="li" listStyleType="decimal">**Predictable**: State is always visible and debuggable</Box>
-      <Box as="li" listStyleType="decimal">**Composable**: Works seamlessly with forms, validation, state management</Box>
-      <Box as="li" listStyleType="decimal">**Testable**: Easy to test all states without user simulation</Box>
-      <Box as="li" listStyleType="decimal">**Standard**: Aligns with React best practices and future direction</Box>
-      <Box as="li" listStyleType="decimal">**Practical**: Matches real-world enterprise application needs</Box>
-    </Box>
-
-    While it requires slightly more boilerplate, this explicitness leads to:
-    <Box as="ul" gap="8" pl="24">
-      <Box as="li" listStyleType="disc">More maintainable code</Box>
-      <Box as="li" listStyleType="disc">Fewer bugs</Box>
-      <Box as="li" listStyleType="disc">Better developer experience over time</Box>
-      <Box as="li" listStyleType="disc">Future-proof architecture</Box>
-    </Box>
+    That is enough to keep the API honest without pretending every form control has the same contract.
 
   </Flex>
 </Unstyled>

--- a/src/storybook/intro.mdx
+++ b/src/storybook/intro.mdx
@@ -1,14 +1,12 @@
 import { Meta, Unstyled } from '@storybook/blocks';
 import { Box } from '../components/Box';
 import { Text } from '../components/Text';
-import { Heading } from '../components/Heading';
 import { Flex, Grid, VStack, HStack } from '@styled-system/jsx';
 import { Link } from '../components/Link';
 import { Divider } from '../components/Divider';
 import { Icon } from '../components/Icon';
 import { IconProvider } from '../components/Icon';
 import { Card } from '../components/Card';
-import { Button } from '../components/Button';
 import '../styles/font-imports.css';
 
 <Meta title="Intro" />
@@ -20,12 +18,38 @@ import '../styles/font-imports.css';
 
 # Cetec ERP Design System
 
-<Text textStyle="body.lg">A React component library built with TypeScript and Panda CSS for the Cetec ERP application and marketing website. This design system provides a comprehensive set of accessible, themeable components following a tokens-first approach.</Text>
+<Text textStyle="body.lg">
+  A React component library built with TypeScript and Panda CSS for the Cetec
+  ERP application and marketing website. This design system provides a
+  comprehensive set of accessible, themeable components following a tokens-first
+  approach.
+</Text>
 
-<Card display="flex" gap="24" px="20" py="12" variant="flat" borderColor="blue.20" borderStyle="dashed" w="fit">
+<Card
+  display="flex"
+  gap="24"
+  px="20"
+  py="12"
+  variant="flat"
+  borderColor="blue.20"
+  borderStyle="dashed"
+  w="fit"
+>
   <Text textStyle="mono.md">origin/main:</Text>
-  <Link href="https://cetec-erp.github.io/Cetec-Design-System/" target="_blank" external>Storybook</Link>
-  <Link href="https://cetec-erp.github.io/Cetec-Design-System/playroom" target="_blank" external>Playroom</Link>
+  <Link
+    href="https://cetec-erp.github.io/Cetec-Design-System/"
+    target="_blank"
+    external
+  >
+    Storybook
+  </Link>
+  <Link
+    href="https://cetec-erp.github.io/Cetec-Design-System/playroom"
+    target="_blank"
+    external
+  >
+    Playroom
+  </Link>
 </Card>
 
 <Divider weight="thick" color="border" my="32" />
@@ -92,7 +116,7 @@ import '../styles/font-imports.css';
       </HStack>
       <HStack gap="8">
         <Icon name="check" size="16" />
-        <Text textStyle="body.sm">Form inputs (TextInput, Textarea, Checkbox, Radio, Toggle)</Text>
+        <Text textStyle="body.sm">Form inputs (TextInput, Textarea, Checkbox, Radio, Toggle, Select, DatePicker, TimePicker, ChipGroup)</Text>
       </HStack>
       <HStack gap="8">
         <Icon name="check" size="16" />

--- a/src/utils/useControllableState.ts
+++ b/src/utils/useControllableState.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react';
+
+export type UseControllableStateProps<T> = {
+  value?: T;
+  defaultValue: T;
+  onChange?: (value: T) => void;
+};
+
+export const useControllableState = <T>({
+  value,
+  defaultValue,
+  onChange,
+}: UseControllableStateProps<T>) => {
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : uncontrolledValue;
+
+  const setValue = useCallback(
+    (nextValue: T | ((currentValue: T) => T)) => {
+      const resolvedValue =
+        typeof nextValue === 'function'
+          ? (nextValue as (currentValue: T) => T)(currentValue)
+          : nextValue;
+
+      if (!isControlled) {
+        setUncontrolledValue(resolvedValue);
+      }
+
+      onChange?.(resolvedValue);
+    },
+    [currentValue, isControlled, onChange],
+  );
+
+  return [currentValue, setValue, isControlled] as const;
+};

--- a/standards/components/controlled-state.md
+++ b/standards/components/controlled-state.md
@@ -1,13 +1,14 @@
 # Controlled State Standard
 
-Interactive components are controlled-first by default.
+Interactive components are controlled-first by default, but dual-mode APIs are allowed where they match native form behavior or materially improve static-rendering compatibility.
 
 ## Hard Standards
 
-1. Default API model is controlled state (`value/checked` + `onChange`).
-2. Overlays and pickers must support controlled visibility (`open` + `onOpenChange`).
-3. Any uncontrolled fallback must be documented as compatibility/transitional behavior, not preferred API.
-4. Value-owning components should emit domain values from `onChange`; emit `null` only for intentional clear.
+1. Default API model is controlled state (`value/checked` + `onChange`) for value-owning widgets.
+2. Native input wrappers and binary controls may expose both controlled and uncontrolled props (`checked` / `defaultChecked`, `value` / `defaultValue`).
+3. Overlays and pickers must support controlled visibility (`open` + `onOpenChange`), and may also expose `defaultOpen` when that improves DX.
+4. Uncontrolled behavior is first-class when it matches native HTML semantics or helps a static page work without hydration. It is not automatically a transitional escape hatch.
+5. Value-owning components should emit domain values from `onChange`; emit `null` only for intentional clear.
 
 ## Hard With Exceptions
 
@@ -15,5 +16,6 @@ Controlled-first can opt out for documented integration scenarios (example: usin
 
 ## Scope Notes
 
-- Native input wrappers (`Checkbox`, `Radio`, `Toggle`) may emit DOM events by design.
+- Native input wrappers (`Checkbox`, `Radio`, `Toggle`) may emit DOM events by design and should respect native checked state for visuals.
+- Grouped selection patterns should use a shared group context (`RadioGroup`, `ChipGroup`) instead of pushing selection state into generic field context.
 - Action components (`MenuItem`) may expose click/action events instead of domain value payloads.

--- a/standards/index.yml
+++ b/standards/index.yml
@@ -6,7 +6,7 @@ components:
   polymorphic-box:
     description: Box + splitProps + cx conventions for all components
   controlled-state:
-    description: Controlled-first state model for inputs, overlays, and pickers
+    description: Controlled-first state model for inputs, overlays, and pickers with dual-mode support where native semantics or static rendering benefit
   floating-ui-integration:
     description: Canonical Floating UI wiring and accessibility requirements
   multi-part-composition:


### PR DESCRIPTION
Summary:

- Added uncontrolled support to the form control family where it fits native semantics: Checkbox, Toggle, Radio, Select, DatePicker, TimePicker, and ChipGroup.
- Added defaultChecked, defaultValue, and defaultOpen entrypoints where appropriate, while keeping the existing controlled APIs intact.
- Introduced RadioGroup for grouped radio selection and updated binary controls to render from native input state so they work correctly in static Astro usage without hydration.
- Updated Storybook, standards docs, README.md, AGENTS.md, and CLAUDE.md to match the new API and usage guidance.

Impact:

- This is additive behavior, not a breaking API change.
- Existing controlled consumers should continue working unchanged.
- Static marketing pages can now use more of the design system without React islands for basic checked/selected state.