### PR TITLE
fix(patch): issue with state for MenuItem toggles

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,13 +1,8 @@
-import type {
-  ChangeEventHandler,
-  HTMLProps,
-  KeyboardEvent,
-  MouseEvent,
-} from 'react';
+import type { HTMLProps, KeyboardEvent, MouseEvent } from 'react';
 
 import { useFloatingTree, useListItem } from '@floating-ui/react';
 
-import { cx } from '@styled-system/css';
+import { css, cx } from '@styled-system/css';
 import { listItem as listItemRecipe } from '@styled-system/recipes';
 
 import { splitProps } from '~/utils/splitProps';
@@ -113,11 +108,6 @@ export const MenuItem = (props: MenuItemProps) => {
     }
   };
 
-  const handleControlChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
   type MenuInteractionProps = Pick<
     HTMLProps<HTMLElement>,
     'onClick' | 'onKeyDown' | 'onPointerMove' | 'onMouseMove' | 'onFocus'
@@ -180,9 +170,6 @@ export const MenuItem = (props: MenuItemProps) => {
       ? 'menuitemcheckbox'
       : 'menuitem';
 
-  // const selectionControl =
-  //   variant === 'checkbox' || variant === 'toggle' ? variant : 'none';
-
   const elementProps: BoxProps<'a'> | BoxProps<'button'> = href
     ? ({
         as: 'a',
@@ -236,21 +223,23 @@ export const MenuItem = (props: MenuItemProps) => {
       {variant === 'checkbox' && (
         <Checkbox
           name={controlName}
-          className={classes.beforeSlot}
+          className={cx(classes.beforeSlot, css({ pointerEvents: 'none' }))}
           checked={Boolean(selected)}
-          onChange={handleControlChange}
+          readOnly
           tabIndex={-1}
+          aria-hidden
         />
       )}
 
       {variant === 'toggle' && (
         <Toggle
           name={controlName}
-          className={classes.beforeSlot}
+          className={cx(classes.beforeSlot, css({ pointerEvents: 'none' }))}
           checked={Boolean(selected)}
-          onChange={handleControlChange}
+          readOnly
           mr="4"
           tabIndex={-1}
+          aria-hidden
         />
       )}
 


### PR DESCRIPTION
### What was broken

`MenuItem` with `variant="toggle"` (and the same pattern for `variant="checkbox"`) could get **visually stuck**: parent state and `selected` kept updating, but the switch/checkbox UI did not.

That showed up most often when clicking the **toggle knob** (the nested control), with `closeOnSelect={false}` so the menu stayed open and you could click repeatedly.

### Why it happened

Those menu items are a single row button (`role="menuitemcheckbox"`) that also rendered a real `Toggle` / `Checkbox` input inside.

Selection was already owned correctly by the row: consumers pass `selected` and update it in `onClick`. The nested control was only meant to look like a toggle/checkbox.

But we wired its `onChange` to call `preventDefault()`. For controlled components, that interferes with React’s click → checked sync. The DOM `:checked` state (which drives our Toggle/Checkbox CSS) could drift from the controlled `checked={selected}` prop — so the app kept toggling while the UI looked stuck.

### What we changed

In `MenuItem` only, treat the nested Toggle/Checkbox as **decorative**:

- Remove the `preventDefault` `onChange` handler
- Ignore pointer events on the control so clicks hit the menu item row
- Mark the input `readOnly` / `aria-hidden` (row still exposes `aria-checked`)

The row remains the only interaction surface. Visuals still follow `selected`. Keyboard activation is unchanged.

This matches how menu checkable items are supposed to work: **one interactive menuitem**, with a visual indicator — not a separate form control inside a button (which is also invalid HTML and a common source of focus/event bugs).

Standalone `Toggle` and `Checkbox` are untouched. Only the MenuItem embedding changes.

### Impact

**No API or behavior contract change** for normal usage:

| Still the same | Notes |
| --- | --- |
| `selected` + `onClick` | Still how you control and update state |
| `closeOnSelect` | Unchanged |
| `aria-checked` / `data-selected` | Still driven by `selected` |
| Keyboard (Enter/Space) | Still activates the menuitem |

Consumers who only used the documented pattern (flip `selected` in `onClick`) should see a bugfix, not a migration. There is no new required prop and no change to exported Toggle/Checkbox APIs.

The only intentional difference: clicking the knob/checkbox area now goes through the **same** row `onClick` path as clicking the label (instead of fighting a nested input). That is the correct menu behavior and is what prevents the stuck visual.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `2.2.2-next.0`

<details>
  <summary>Changelog</summary>

  #### ⚠️ Pushed to `main`
  
  - fix: release ([@Etwigg](https://github.com/Etwigg))
  
  #### 📦 Misc Changes
  
  - refactor: pass href prop to render listitem as anchor [#165](https://github.com/Cetec-ERP/Cetec-Design-System/pull/165) ([@atkinsdavid](https://github.com/atkinsdavid))
  - refactor(minor): remove compound variants and support responsive sizing [#154](https://github.com/Cetec-ERP/Cetec-Design-System/pull/154) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### 🚀 Features
  
  - feat: shadow refactor to add dropShadow property and tokens [#170](https://github.com/Cetec-ERP/Cetec-Design-System/pull/170) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): add uncontrolled support and static-safe visuals for form components [#169](https://github.com/Cetec-ERP/Cetec-Design-System/pull/169) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): select-component [#158](https://github.com/Cetec-ERP/Cetec-Design-System/pull/158) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - feat: added skeleton component and stories [#166](https://github.com/Cetec-ERP/Cetec-Design-System/pull/166) ([@shaunrfox](https://github.com/shaunrfox))
  - feat: keyboard-component [#159](https://github.com/Cetec-ERP/Cetec-Design-System/pull/159) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): add keyboard UI for Menu components [#153](https://github.com/Cetec-ERP/Cetec-Design-System/pull/153) ([@atkinsdavid](https://github.com/atkinsdavid))
  
  #### 🐛 Bug Fixes
  
  - fix(patch): issue with state for MenuItem toggles [#173](https://github.com/Cetec-ERP/Cetec-Design-System/pull/173) ([@atkinsdavid](https://github.com/atkinsdavid))
  - fix: shared field and slot context layers + arbitrary slot handling [#160](https://github.com/Cetec-ERP/Cetec-Design-System/pull/160) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - fix: try to fix versioning again [#164](https://github.com/Cetec-ERP/Cetec-Design-System/pull/164) ([@Etwigg](https://github.com/Etwigg))
  - fix(patch): block !important in validation checks [#149](https://github.com/Cetec-ERP/Cetec-Design-System/pull/149) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  
  #### 🎨 Styles
  
  - style: fixed conditional styling scope to prevent affects from ancestor data attributes [#172](https://github.com/Cetec-ERP/Cetec-Design-System/pull/172) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### 🤖 CI
  
  - ci: added manual release workflow [#171](https://github.com/Cetec-ERP/Cetec-Design-System/pull/171) ([@shaunrfox](https://github.com/shaunrfox))
  - ci: fix prerelease in ci [#168](https://github.com/Cetec-ERP/Cetec-Design-System/pull/168) ([@Etwigg](https://github.com/Etwigg))
  - ci: better version resolution [#161](https://github.com/Cetec-ERP/Cetec-Design-System/pull/161) ([@Etwigg](https://github.com/Etwigg))
  
  #### 🏠 Chores
  
  - chore(patch): added semantic fontSizes [#167](https://github.com/Cetec-ERP/Cetec-Design-System/pull/167) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - chore(major): trigger prerelease for #154 [#157](https://github.com/Cetec-ERP/Cetec-Design-System/pull/157) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - chore(minor): trigger prerelease for #154 [#156](https://github.com/Cetec-ERP/Cetec-Design-System/pull/156) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### Authors: 3
  
  - David ([@atkinsdavid](https://github.com/atkinsdavid))
  - Ethan W. ([@Etwigg](https://github.com/Etwigg))
  - Shaun Fox ([@shaunrfox](https://github.com/shaunrfox))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
