### PR TITLE
fix: ai review fixes

### DIFF
--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -73,14 +73,17 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: function DefaultRender(args) {
-    const [value, setValue] = useState<string | string[] | null>(null);
+    const [value, setValue] = useState<string | null>(null);
 
     return (
       <Box w="xs">
         <Autocomplete
           {...args}
+          multiple={false}
           value={value}
+          defaultValue={undefined}
           onValueChange={setValue}
+          onChange={undefined}
           name="technology"
         >
           {renderOptions()}
@@ -126,7 +129,15 @@ export const Filtering: Story = {
 export const Selected: Story = {
   render: (args) => (
     <Box w="xs">
-      <Autocomplete {...args} defaultValue="react" name="technology">
+      <Autocomplete
+        {...args}
+        multiple={false}
+        value={undefined}
+        defaultValue="react"
+        onValueChange={undefined}
+        onChange={undefined}
+        name="technology"
+      >
         {renderOptions()}
       </Autocomplete>
     </Box>
@@ -164,6 +175,23 @@ export const Multiple: Story = {
       </Box>
     );
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const input = canvas.getByRole('combobox');
+    const removeReact = canvas.getByRole('button', {
+      name: 'Remove React',
+    });
+
+    await userEvent.click(input);
+    await expect(body.queryByRole('checkbox')).not.toBeInTheDocument();
+    await userEvent.click(removeReact);
+    await expect(
+      canvas.queryByRole('button', { name: 'Remove React' }),
+    ).not.toBeInTheDocument();
+    await expect(input).toHaveFocus();
+  },
+  parameters: { controls: { disable: true } },
 };
 
 export const MultipleLongValues: Story = {
@@ -414,6 +442,12 @@ export const ControlledInput: Story = {
 export const ControlledOpen: Story = {
   render: function ControlledOpenRender() {
     const [open, setOpen] = useState(false);
+    const [openChangeCount, setOpenChangeCount] = useState(0);
+
+    const handleOpenChange = (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      setOpenChangeCount((currentCount) => currentCount + 1);
+    };
 
     return (
       <Box display="grid" gap="8" w="sm">
@@ -422,14 +456,25 @@ export const ControlledOpen: Story = {
         </Button>
         <Autocomplete
           open={open}
-          onOpenChange={setOpen}
+          onOpenChange={handleOpenChange}
           name="controlled-open"
           aria-label="Controlled suggestions"
         >
           {renderOptions()}
         </Autocomplete>
+        <Box color="text.subtle">{`Open changes: ${openChangeCount}`}</Box>
       </Box>
     );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.click(input);
+    await expect(canvas.getByText('Open changes: 1')).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    await expect(canvas.getByText('Open changes: 2')).toBeInTheDocument();
+    await expect(input).toHaveAttribute('aria-expanded', 'false');
   },
   parameters: { controls: { disable: true } },
 };

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -25,7 +25,7 @@ import type {
   AutocompleteValue,
 } from './types';
 
-export type AutocompleteProps<Multiple extends boolean = boolean> = Omit<
+type AutocompleteBaseProps = Omit<
   BoxProps<'div'>,
   | keyof AutocompleteVariantProps
   | 'children'
@@ -34,17 +34,6 @@ export type AutocompleteProps<Multiple extends boolean = boolean> = Omit<
   | 'value'
 > &
   AutocompleteVariantProps & {
-    value?: AutocompleteValue<Multiple>;
-    defaultValue?: AutocompleteValue<Multiple>;
-    onValueChange?: (
-      value: AutocompleteValue<Multiple>,
-      reason: AutocompleteChangeReason,
-    ) => void;
-    /** @deprecated Use onValueChange. */
-    onChange?: (
-      value: AutocompleteValue<Multiple>,
-      reason: AutocompleteChangeReason,
-    ) => void;
     inputValue?: string;
     defaultInputValue?: string;
     onInputValueChange?: (
@@ -62,7 +51,6 @@ export type AutocompleteProps<Multiple extends boolean = boolean> = Omit<
       open: boolean,
       reason: AutocompleteOpenChangeReason,
     ) => void;
-    multiple?: Multiple;
     allowCustomValue?: boolean;
     getCreateOptionLabel?: (inputValue: string) => string;
     limitTags?: number;
@@ -86,9 +74,44 @@ export type AutocompleteProps<Multiple extends boolean = boolean> = Omit<
     noOptionsText?: ReactNode;
   };
 
-export const Autocomplete = <Multiple extends boolean = boolean>(
-  props: AutocompleteProps<Multiple>,
-) => {
+export type SingleAutocompleteProps = AutocompleteBaseProps & {
+  multiple?: false;
+  value?: AutocompleteValue<false>;
+  defaultValue?: AutocompleteValue<false>;
+  onValueChange?: (
+    value: AutocompleteValue<false>,
+    reason: AutocompleteChangeReason,
+  ) => void;
+  /** @deprecated Use onValueChange. */
+  onChange?: (
+    value: AutocompleteValue<false>,
+    reason: AutocompleteChangeReason,
+  ) => void;
+};
+
+export type MultipleAutocompleteProps = AutocompleteBaseProps & {
+  multiple: true;
+  value?: AutocompleteValue<true>;
+  defaultValue?: AutocompleteValue<true>;
+  onValueChange?: (
+    value: AutocompleteValue<true>,
+    reason: AutocompleteChangeReason,
+  ) => void;
+  /** @deprecated Use onValueChange. */
+  onChange?: (
+    value: AutocompleteValue<true>,
+    reason: AutocompleteChangeReason,
+  ) => void;
+};
+
+export type AutocompleteProps<Multiple extends boolean = boolean> =
+  Multiple extends true
+    ? MultipleAutocompleteProps
+    : Multiple extends false
+      ? SingleAutocompleteProps
+      : SingleAutocompleteProps | MultipleAutocompleteProps;
+
+export const Autocomplete = (props: AutocompleteProps) => {
   const controller = useAutocompleteController(props);
   const {
     activeIndex,
@@ -120,6 +143,7 @@ export const Autocomplete = <Multiple extends boolean = boolean>(
     handleInputMouseDown,
     handleListScroll,
     handleOptionSelect,
+    handleTokenDismiss,
     handleTokenKeyDown,
     hiddenTagCount,
     inputId,
@@ -137,7 +161,6 @@ export const Autocomplete = <Multiple extends boolean = boolean>(
     otherProps,
     placeholder,
     readOnly,
-    removeSelectedValue,
     rootRef,
     selectedLabels,
     selectedValues,
@@ -193,7 +216,7 @@ export const Autocomplete = <Multiple extends boolean = boolean>(
                   label={label}
                   disabled={disabled || readOnly}
                   dismissButtonRef={(node) => setTokenRef(index, node)}
-                  onDismiss={() => removeSelectedValue(selectedValue, label)}
+                  onDismiss={() => handleTokenDismiss(selectedValue, label)}
                   onKeyDown={(event) =>
                     handleTokenKeyDown(event, index, selectedValue, label)
                   }

--- a/src/components/Autocomplete/AutocompleteListbox.tsx
+++ b/src/components/Autocomplete/AutocompleteListbox.tsx
@@ -12,6 +12,7 @@ import { menu } from '@styled-system/recipes';
 import type { MenuDensity } from '~/components/Menu';
 
 import { Box } from '../Box';
+import { Icon } from '../Icon';
 import { List, ListItem } from '../List';
 
 import type { AnyAutocompleteValue, AutocompleteOptionData } from './types';
@@ -99,7 +100,15 @@ export const AutocompleteListbox = (props: AutocompleteListboxProps) => {
             disabled={option.disabled}
             selected={selected}
             density={density}
-            variant={multiple ? 'checkbox' : 'default'}
+            before={
+              multiple ? (
+                <Icon
+                  name={selected ? 'checkbox-checked' : 'checkbox'}
+                  fill={selected ? 'icon' : 'icon.subtlest'}
+                  aria-hidden
+                />
+              ) : undefined
+            }
             label={option.label}
             description={option.description}
             iconBefore={option.iconLeft}

--- a/src/components/Autocomplete/useAutocompleteController.ts
+++ b/src/components/Autocomplete/useAutocompleteController.ts
@@ -38,7 +38,11 @@ import {
   normalizeAutocompleteOptions,
 } from './utils';
 
-import type { AutocompleteProps } from './Autocomplete';
+import type {
+  AutocompleteProps,
+  MultipleAutocompleteProps,
+  SingleAutocompleteProps,
+} from './Autocomplete';
 import type {
   AnyAutocompleteValue,
   AutocompleteChangeReason,
@@ -82,9 +86,7 @@ const getDismissReason = (
   return reason === 'escape-key' ? 'escape' : 'outside-press';
 };
 
-export const useAutocompleteController = <Multiple extends boolean = boolean>(
-  props: AutocompleteProps<Multiple>,
-) => {
+export const useAutocompleteController = (props: AutocompleteProps) => {
   const fieldContext = useFieldContext();
   const {
     value: controlledValue,
@@ -98,7 +100,7 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
     open: controlledOpen,
     defaultOpen,
     onOpenChange,
-    multiple = false as Multiple,
+    multiple = false,
     allowCustomValue = false,
     getCreateOptionLabel = defaultGetCreateOptionLabel,
     limitTags,
@@ -168,13 +170,30 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
       : '';
   const handleValueChange = useCallback(
     (
-      nextValue: AutocompleteValue<Multiple>,
+      nextValue: AutocompleteValue<boolean>,
       reason: AutocompleteChangeReason,
     ) => {
-      onValueChange?.(nextValue, reason);
-      onChange?.(nextValue, reason);
+      if (multiple) {
+        const multipleValue = nextValue as AutocompleteValue<true>;
+        (onValueChange as MultipleAutocompleteProps['onValueChange'])?.(
+          multipleValue,
+          reason,
+        );
+        (onChange as MultipleAutocompleteProps['onChange'])?.(
+          multipleValue,
+          reason,
+        );
+        return;
+      }
+
+      const singleValue = nextValue as AutocompleteValue<false>;
+      (onValueChange as SingleAutocompleteProps['onValueChange'])?.(
+        singleValue,
+        reason,
+      );
+      (onChange as SingleAutocompleteProps['onChange'])?.(singleValue, reason);
     },
-    [onChange, onValueChange],
+    [multiple, onChange, onValueChange],
   );
   const handleInputValueChange = useCallback(
     (nextValue: string, reason: AutocompleteInputChangeReason) => {
@@ -184,7 +203,7 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
     [onInputChange, onInputValueChange],
   );
 
-  const state = useAutocompleteState<Multiple>({
+  const state = useAutocompleteState<boolean>({
     value: controlledValue,
     defaultValue,
     onValueChange: handleValueChange,
@@ -360,6 +379,13 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
     },
     [state],
   );
+  const handleTokenDismiss = useCallback(
+    (selectedValue: string, label: string) => {
+      removeSelectedValue(selectedValue, label);
+      requestAnimationFrame(focusInput);
+    },
+    [focusInput, removeSelectedValue],
+  );
 
   const handleTokenKeyDown = useCallback(
     (
@@ -463,13 +489,6 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
           event.preventDefault();
           handleOptionSelect(activeOption);
         }
-        return;
-      }
-
-      if (event.key === 'Escape' && isOpen) {
-        event.preventDefault();
-        setActiveIndex(null);
-        state.closePopup('escape');
         return;
       }
 
@@ -614,6 +633,7 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
     handleInputMouseDown,
     handleListScroll,
     handleOptionSelect,
+    handleTokenDismiss,
     handleTokenKeyDown,
     hiddenTagCount,
     inputId,
@@ -631,7 +651,6 @@ export const useAutocompleteController = <Multiple extends boolean = boolean>(
     otherProps,
     placeholder,
     readOnly,
-    removeSelectedValue,
     rootRef,
     selectedLabels,
     selectedValues,

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEventHandler } from 'react';
+import type { ChangeEventHandler, ReactNode } from 'react';
 
 import { cx } from '@styled-system/css';
 import { listItem, type ListItemVariantProps } from '@styled-system/recipes';
@@ -22,6 +22,7 @@ export type ListItemProps = Omit<
 > &
   Omit<ListItemVariantProps, 'selected' | 'iconBefore' | 'iconAfter'> & {
     href?: string;
+    before?: ReactNode;
     label?: string;
     description?: string;
     query?: string;
@@ -42,6 +43,7 @@ export const ListItem = (props: ListItemProps) => {
     selected = false,
     density,
     variant = 'default',
+    before,
     label,
     description,
     query,
@@ -106,6 +108,12 @@ export const ListItem = (props: ListItemProps) => {
         children
       ) : (
         <>
+          {before && (
+            <Box className={classes.beforeSlot} aria-hidden>
+              {before}
+            </Box>
+          )}
+
           {variant === 'checkbox' && (
             <Checkbox
               name={controlName}


### PR DESCRIPTION
This branch fixes four Autocomplete review findings:
Type-safe selection modes: array values now require multiple={true}. Existing AutocompleteProps<true> and <false> usage remains compatible.
Single Escape handling: removed the duplicate local Escape handler so Floating UI closes the popup and calls onOpenChange only once.
Focus restoration: clicking a token’s remove button now returns focus to the Autocomplete input.
Valid option semantics: multi-select options use decorative checkbox icons instead of nesting native checkboxes inside option buttons.
It also adds Storybook interaction coverage for Escape callback counts, token-removal focus, and checkbox-free option semantics. ListItem gained a generic decorative before slot to support the new option indicator.