### PR TITLE
feat(minor): emit data-ds-component on component roots

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -7,6 +7,7 @@ import { avatar, type AvatarVariantProps } from '@styled-system/recipes';
 import { Box, type BoxProps } from '~/components/Box';
 import { Icon, type AllowedIconSizes, type IconProps } from '~/components/Icon';
 import { useSlotContext } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Supported visual sizes for {@link Avatar}. */
@@ -162,6 +163,7 @@ export const Avatar = (props: AvatarProps) => {
 
   return (
     <Box
+      {...dsComponent('Avatar')}
       as="span"
       ref={ref}
       className={cx(classes.root, className)}

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { expect, within } from '@storybook/test';
+
 import { Grid, VStack, Flex } from '@styled-system/jsx';
 
 import { Box } from '../Box';
@@ -73,6 +75,33 @@ export const DotStandalone: Story = {
       <Badge size="xl" />
     </Box>
   ),
+};
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <VStack alignItems="start" gap="8">
+      <Badge aria-label="Default badge" count={5} />
+      <Badge
+        aria-label="Overridden badge"
+        count={5}
+        data-ds-component="NotificationCount"
+      />
+    </VStack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByLabelText('Default badge')).toHaveAttribute(
+      'data-ds-component',
+      'Badge',
+    );
+    expect(canvas.getByLabelText('Overridden badge')).toHaveAttribute(
+      'data-ds-component',
+      'NotificationCount',
+    );
+  },
+  parameters: { controls: { disable: true } },
 };
 
 export const DotWithChildren: Story = {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -133,6 +133,7 @@ export const Badge = (props: BadgeProps) => {
   if (isStandalone) {
     return (
       <Box
+        {...dsComponent('Badge')}
         as="span"
         ref={ref}
         className={cx(classes.root, className)}

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -5,6 +5,7 @@ import { badge, type BadgeVariantProps } from '@styled-system/recipes';
 
 import { Box, type BoxProps } from '~/components/Box';
 import { useSlotContext } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Supported visual color treatments for {@link Badge}. */
@@ -145,6 +146,7 @@ export const Badge = (props: BadgeProps) => {
   // Wrapper mode: wrap children with positioned indicator
   return (
     <Box
+      {...dsComponent('Badge')}
       as="span"
       ref={ref}
       className={cx(classes.root, className)}

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,6 +2,7 @@ import { cx } from '@styled-system/css';
 import type { BreadcrumbsVariantProps } from '@styled-system/recipes';
 import { breadcrumbs } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { type BoxProps } from '../Box';
@@ -42,7 +43,12 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
   const classes = breadcrumbs();
 
   return (
-    <Text as="ul" className={cx(classes.wrapper, className)} {...otherProps}>
+    <Text
+      {...dsComponent('Breadcrumbs')}
+      as="ul"
+      className={cx(classes.wrapper, className)}
+      {...otherProps}
+    >
       {items?.map((item, index) => (
         <Text as="li" key={item.id}>
           {item.href ? (

--- a/src/components/BreakpointIndicator/BreakpointIndicator.tsx
+++ b/src/components/BreakpointIndicator/BreakpointIndicator.tsx
@@ -5,6 +5,7 @@ import {
 } from '@styled-system/recipes';
 
 import { useMediaQuery } from '~/system/hooks';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Tag } from '../Tag';
@@ -45,10 +46,12 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
 
   const { variant, ...rest } = props;
   const [className, otherProps] = splitProps(rest);
+  const dsAttributes = dsComponent('BreakpointIndicator');
 
   // Find the largest matching breakpoint
   let breakpoint = (
     <Tag
+      {...dsAttributes}
       className={cx(breakpointIndicator({ variant }), className)}
       hue="red"
       variant="bold"
@@ -60,6 +63,7 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
   if (is2Xl) {
     breakpoint = (
       <Tag
+        {...dsAttributes}
         className={cx(breakpointIndicator({ variant }), className)}
         hue="blue"
         variant="bold"
@@ -71,6 +75,7 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
   } else if (isXl) {
     breakpoint = (
       <Tag
+        {...dsAttributes}
         className={cx(breakpointIndicator({ variant }), className)}
         hue="magenta"
         variant="bold"
@@ -82,6 +87,7 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
   } else if (isLg) {
     breakpoint = (
       <Tag
+        {...dsAttributes}
         className={cx(breakpointIndicator({ variant }), className)}
         hue="green"
         variant="bold"
@@ -93,6 +99,7 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
   } else if (isMd) {
     breakpoint = (
       <Tag
+        {...dsAttributes}
         className={cx(breakpointIndicator({ variant }), className)}
         hue="indigo"
         variant="bold"
@@ -104,6 +111,7 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
   } else if (isSm) {
     breakpoint = (
       <Tag
+        {...dsAttributes}
         className={cx(breakpointIndicator({ variant }), className)}
         hue="yellow"
         variant="bold"
@@ -115,6 +123,7 @@ export const BreakpointIndicator = (props: BreakpointIndicatorProps) => {
   } else if (isXs) {
     breakpoint = (
       <Tag
+        {...dsAttributes}
         className={cx(breakpointIndicator({ variant }), className)}
         hue="orange"
         variant="bold"

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { fn } from '@storybook/test';
+import { expect, fn, within } from '@storybook/test';
 
 import { HStack, Wrap, Grid, VStack } from '@styled-system/jsx';
 
@@ -542,6 +542,32 @@ export const FormSubmitting: Story = {
       </Button>
     </HStack>
   ),
+  parameters: { controls: { disable: true } },
+};
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <HStack gap="8">
+      <Button>Default</Button>
+      <Button data-ds-component="CustomButton">Overridden</Button>
+    </HStack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Emitted automatically on the root element, without an author opting in.
+    expect(canvas.getByRole('button', { name: 'Default' })).toHaveAttribute(
+      'data-ds-component',
+      'Button',
+    );
+
+    // An explicitly passed value arrives through rest props and wins.
+    expect(canvas.getByRole('button', { name: 'Overridden' })).toHaveAttribute(
+      'data-ds-component',
+      'CustomButton',
+    );
+  },
   parameters: { controls: { disable: true } },
 };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,6 +13,7 @@ import {
   type SlotPlacement,
   useSlotContext,
 } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /**
@@ -185,6 +186,7 @@ export const Button = (props: ButtonProps) => {
 
   return (
     <Box
+      {...dsComponent('Button')}
       {...(href
         ? ({
             as: 'a',

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -17,6 +17,7 @@ import {
 } from '~/components/DateTime/helpers';
 import { IconButton } from '~/components/IconButton';
 import { Text } from '~/components/Text';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 // ─── Static data ────────────────────────────────────────────────────────────────
@@ -552,6 +553,7 @@ export const Calendar = (props: CalendarProps) => {
 
   return (
     <Box
+      {...dsComponent('Calendar')}
       className={cx(classes.root, className)}
       role="group"
       aria-label={label}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent, ReactNode } from 'react';
 import { cx } from '@styled-system/css';
 import { card, type CardVariantProps } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -56,6 +57,7 @@ export const Card = (props: CardProps) => {
 
   return (
     <Box
+      {...dsComponent('Card')}
       {...(href
         ? ({
             as: 'a',

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { checkbox, type CheckboxVariantProps } from '@styled-system/recipes';
 
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -80,6 +81,7 @@ export const Checkbox = (props: CheckboxProps) => {
     input,
     indicator,
     checkBg,
+    'data-ds-component': dsComponentName,
     ...rest
   } = props;
   const disabled = disabledProp ?? fieldContext?.disabled;
@@ -103,6 +105,7 @@ export const Checkbox = (props: CheckboxProps) => {
 
   return (
     <Box
+      {...dsComponent('Checkbox', dsComponentName)}
       className={cx(classes.container, className)}
       {...(error && { 'data-error': true })}
       {...(invalid && { 'data-invalid': true })}

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -7,6 +7,7 @@ import {
 } from '@styled-system/recipes';
 
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { type BoxProps } from '../Box';
@@ -74,6 +75,7 @@ export const CheckboxInput = (props: CheckboxInputProps) => {
   const resolvedId = id ?? generatedId;
   return (
     <Label
+      {...dsComponent('CheckboxInput')}
       className={cx(checkboxInput(), className)}
       htmlFor={resolvedId}
       disabled={disabled}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -21,6 +21,7 @@ import {
   type SlotPlacement,
   useSlotContext,
 } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { useChipGroup } from './ChipGroupContext';
@@ -345,6 +346,7 @@ export const Chip = (props: ChipProps) => {
 
   return (
     <Box
+      {...dsComponent('Chip')}
       className={`${cx(classes.container, className)} group`}
       data-loading={loading ? true : undefined}
       data-deleted={deleted ? true : undefined}

--- a/src/components/Chip/ChipGroup.tsx
+++ b/src/components/Chip/ChipGroup.tsx
@@ -12,6 +12,7 @@ import { Wrap, type WrapProps } from '@styled-system/jsx';
 
 import { type BoxProps } from '~/components/Box';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 import { useControllableState } from '~/utils/useControllableState';
 
@@ -192,6 +193,7 @@ export const ChipGroup = (props: ChipGroupProps) => {
   return (
     <ChipGroupContext.Provider value={contextValue}>
       <Wrap
+        {...dsComponent('ChipGroup')}
         className={cx(stylesClassName, className)}
         role={role}
         aria-label={label}

--- a/src/components/Code/Code.stories.tsx
+++ b/src/components/Code/Code.stories.tsx
@@ -1,3 +1,5 @@
+import { expect, within } from '@storybook/test';
+
 import { Box } from '../Box';
 import { Text } from '../Text';
 
@@ -43,6 +45,37 @@ export function SaveAction() {
 }`}</Pre>
     </Box>
   ),
+  parameters: { controls: { disable: true } },
+};
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <>
+      <Pre>{'const defaultPre = true;'}</Pre>
+      <Pre data-ds-component="ExamplePre">{'const customPre = true;'}</Pre>
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const defaultPre = canvas
+      .getByText('const defaultPre = true;')
+      .closest('pre');
+    const customPre = canvas
+      .getByText('const customPre = true;')
+      .closest('pre');
+
+    expect(defaultPre).toHaveAttribute('data-ds-component', 'Pre');
+    expect(defaultPre?.querySelector('code')).toHaveAttribute(
+      'data-ds-component',
+      'Code',
+    );
+    expect(customPre).toHaveAttribute('data-ds-component', 'ExamplePre');
+    expect(customPre?.querySelector('code')).toHaveAttribute(
+      'data-ds-component',
+      'Code',
+    );
+  },
   parameters: { controls: { disable: true } },
 };
 

--- a/src/components/Code/Code.tsx
+++ b/src/components/Code/Code.tsx
@@ -5,6 +5,7 @@ import { code, type CodeVariantProps } from '@styled-system/recipes';
 
 import { Box, type BoxProps } from '~/components/Box';
 import { Text, type TextProps } from '~/components/Text';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Props accepted by {@link Code}. */
@@ -36,6 +37,7 @@ export const Code = (props: CodeProps) => {
   const [className, otherProps] = splitProps(rest);
   return (
     <Box
+      {...dsComponent('Code')}
       as="code"
       className={cx(code({}), className)}
       lang={lang}

--- a/src/components/Code/Pre.tsx
+++ b/src/components/Code/Pre.tsx
@@ -33,11 +33,16 @@ export type PreProps = Omit<BoxProps, keyof PreOwnProps> & PreOwnProps;
  * ```
  */
 export const Pre = (props: PreProps) => {
-  const { children, lang, ...rest } = props;
+  const {
+    children,
+    lang,
+    'data-ds-component': dsComponentName,
+    ...rest
+  } = props;
   const [className, otherProps] = splitProps(rest);
   return (
     <Box
-      {...dsComponent('Pre')}
+      {...dsComponent('Pre', dsComponentName)}
       as="pre"
       className={cx(pre({}), className)}
       {...otherProps}

--- a/src/components/Code/Pre.tsx
+++ b/src/components/Code/Pre.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { pre } from '@styled-system/recipes';
 
 import { Box, type BoxProps } from '~/components/Box';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Code } from './Code';
@@ -35,7 +36,12 @@ export const Pre = (props: PreProps) => {
   const { children, lang, ...rest } = props;
   const [className, otherProps] = splitProps(rest);
   return (
-    <Box as="pre" className={cx(pre({}), className)} {...otherProps}>
+    <Box
+      {...dsComponent('Pre')}
+      as="pre"
+      className={cx(pre({}), className)}
+      {...otherProps}
+    >
       <Code lang={lang} slot="react" bg="transparent" {...otherProps}>
         {children}
       </Code>

--- a/src/components/DateTime/inputs/DateInput.tsx
+++ b/src/components/DateTime/inputs/DateInput.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Icon, type IconNamesList } from '~/components/Icon';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../../Box';
@@ -109,6 +110,7 @@ export const DateInput = (props: DateInputProps) => {
 
   return (
     <Box
+      {...dsComponent('DateInput')}
       className={cx(classes.container, className)}
       aria-disabled={disabled}
       data-disabled={disabled || undefined}

--- a/src/components/DateTime/inputs/DateRangeInput.tsx
+++ b/src/components/DateTime/inputs/DateRangeInput.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Icon, type IconNamesList } from '~/components/Icon';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../../Box';
@@ -153,6 +154,7 @@ export const DateRangeInput = (props: DateRangeInputProps) => {
 
   return (
     <Box
+      {...dsComponent('DateRangeInput')}
       id={id}
       className={cx(classes.container, className)}
       aria-disabled={disabled}

--- a/src/components/DateTime/inputs/DateTimeInput.tsx
+++ b/src/components/DateTime/inputs/DateTimeInput.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Icon, type IconNamesList } from '~/components/Icon';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../../Box';
@@ -170,6 +171,7 @@ export const DateTimeInput = (props: DateTimeInputProps) => {
 
   return (
     <Box
+      {...dsComponent('DateTimeInput')}
       id={id}
       className={cx(classes.container, className)}
       aria-disabled={disabled}

--- a/src/components/DateTime/inputs/TimeInput.tsx
+++ b/src/components/DateTime/inputs/TimeInput.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Icon, type IconNamesList } from '~/components/Icon';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../../Box';
@@ -112,6 +113,7 @@ export const TimeInput = (props: TimeInputProps) => {
 
   return (
     <Box
+      {...dsComponent('TimeInput')}
       className={cx(classes.container, className)}
       aria-disabled={disabled}
       data-disabled={disabled || undefined}

--- a/src/components/DateTime/inputs/TimeRangeInput.tsx
+++ b/src/components/DateTime/inputs/TimeRangeInput.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Icon, type IconNamesList } from '~/components/Icon';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../../Box';
@@ -155,6 +156,7 @@ export const TimeRangeInput = (props: TimeRangeInputProps) => {
 
   return (
     <Box
+      {...dsComponent('TimeRangeInput')}
       id={id}
       className={cx(classes.container, className)}
       aria-disabled={disabled}

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@styled-system/css';
 import { divider, type DividerVariantProps } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -32,6 +33,7 @@ export const Divider = (props: DividerProps) => {
   const [className, otherProps] = splitProps(rest);
   return (
     <Box
+      {...dsComponent('Divider')}
       as="div"
       className={cx(divider({ direction, weight }), className)}
       {...otherProps}

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -6,6 +6,7 @@ import { formField, type FormFieldVariantProps } from '@styled-system/recipes';
 import type { SpacingToken } from '@styled-system/tokens';
 
 import { FieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -136,6 +137,7 @@ export const FormField = (props: FormFieldProps) => {
 
   return (
     <Box
+      {...dsComponent('FormField')}
       className={`${cx(classes.container, className)} group`}
       aria-disabled={disabled}
       data-disabled={disabled || undefined}

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -1,3 +1,5 @@
+import { expect, within } from '@storybook/test';
+
 import { Flex, VStack, Grid } from '@styled-system/jsx';
 
 import { BreakpointIndicator } from '../BreakpointIndicator';
@@ -114,6 +116,35 @@ export const ExContentHierarchy: Story = {
       </Flex>
     </VStack>
   ),
+  parameters: { controls: { disable: true } },
+};
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <VStack alignItems="start" gap="8">
+      <Heading level="h3">Composed heading</Heading>
+      <Text>Plain text</Text>
+      <Heading level="h3" data-ds-component="PageTitle">
+        Overridden heading
+      </Heading>
+    </VStack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Heading renders through Text; the outermost component name wins.
+    expect(
+      canvas.getByRole('heading', { name: 'Composed heading' }),
+    ).toHaveAttribute('data-ds-component', 'Heading');
+    expect(canvas.getByText('Plain text')).toHaveAttribute(
+      'data-ds-component',
+      'Text',
+    );
+    expect(
+      canvas.getByRole('heading', { name: 'Overridden heading' }),
+    ).toHaveAttribute('data-ds-component', 'PageTitle');
+  },
   parameters: { controls: { disable: true } },
 };
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { heading, type HeadingVariantProps } from '@styled-system/recipes';
 
 import { Text, type TextProps } from '~/components/Text';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Props accepted by {@link Heading}. */
@@ -31,6 +32,7 @@ export const Heading = (props: HeadingProps) => {
   const [className, otherProps] = splitProps(rest);
   return (
     <Text
+      {...dsComponent('Heading')}
       as={level}
       className={cx(heading({ level, allCaps }), className)}
       {...otherProps}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -5,6 +5,7 @@ import type { ColorToken } from '@styled-system/tokens';
 import { Box, type BoxProps } from '~/components/Box';
 import type { numericSizes } from '~/styles/primitives';
 import { useSlotContext } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { useIconConfig } from './IconContext';
@@ -77,6 +78,7 @@ export const Icon = (props: IconProps) => {
 
   return (
     <Box
+      {...dsComponent('Icon')}
       as="svg"
       name={name}
       viewBox="0 0 24 24"

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -12,6 +12,7 @@ import { Spinner } from '~/components/Spinner';
 import { Tooltip } from '~/components/Tooltip';
 import { useFieldContext } from '~/system/context/FieldContext';
 import { useSlotContext } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /**
@@ -97,6 +98,7 @@ export const IconButton = (props: IconButtonProps) => {
   return (
     <Tooltip text={altText}>
       <Box
+        {...dsComponent('IconButton')}
         {...(href
           ? ({
               as: 'a',

--- a/src/components/Kbd/Kbd.tsx
+++ b/src/components/Kbd/Kbd.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@styled-system/css';
 import { kbd } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -41,6 +42,7 @@ export const Kbd = (props: KbdProps) => {
   });
   const content = (
     <Box
+      {...dsComponent('Kbd')}
       as="span"
       className={cx(defaultClasses.kbdGroup, className)}
       {...otherProps}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { cx } from '@styled-system/css';
 import { label, type LabelVariantProps } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -32,6 +33,7 @@ export const Label = (props: LabelProps) => {
   const [className, otherProps] = splitProps(rest);
   return (
     <Box
+      {...dsComponent('Label')}
       as="label"
       htmlFor={htmlFor}
       className={cx(label({}), className)}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { link, type LinkVariantProps } from '@styled-system/recipes';
 import { type FontToken, type FontWeightToken } from '@styled-system/tokens';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -74,6 +75,7 @@ export const Link = (props: LinkProps) => {
 
   return (
     <Box
+      {...dsComponent('Link')}
       as="a"
       href={href}
       target={external ? '_blank' : undefined}

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
+
+import { expect, within } from '@storybook/test';
 
 import { HStack, VStack } from '@styled-system/jsx';
 
@@ -39,6 +40,20 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => <ListItem variant="divider" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByRole('separator').parentElement).toHaveAttribute(
+      'data-ds-component',
+      'ListItem',
+    );
+  },
+  parameters: { controls: { disable: true } },
+};
 
 const SingleSelectExample = () => {
   const [selected, setSelected] = useState(items[1]?.id ?? '');

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -3,6 +3,7 @@ import { useMemo, type ReactNode } from 'react';
 import { cx } from '@styled-system/css';
 import { list, type ListVariantProps } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -78,7 +79,11 @@ export const List = (props: ListProps) => {
 
   return (
     <ListProvider value={value}>
-      <Box {...otherProps} className={cx(list({ density }), className)}>
+      <Box
+        {...dsComponent('List')}
+        {...otherProps}
+        className={cx(list({ density }), className)}
+      >
         {children}
       </Box>
     </ListProvider>

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -116,6 +116,7 @@ export const ListItem = (props: ListItemProps) => {
     iconBeforeFill,
     iconAfterFill,
     href,
+    'data-ds-component': dsComponentName,
     ...rest
   } = props;
   const [className, otherProps] = splitProps(rest);
@@ -141,7 +142,10 @@ export const ListItem = (props: ListItemProps) => {
 
   if (variant === 'divider') {
     return (
-      <Box className={classes.divider}>
+      <Box
+        {...dsComponent('ListItem', dsComponentName)}
+        className={classes.divider}
+      >
         <Divider role="separator" />
       </Box>
     );
@@ -149,7 +153,7 @@ export const ListItem = (props: ListItemProps) => {
 
   return (
     <Box
-      {...dsComponent('ListItem')}
+      {...dsComponent('ListItem', dsComponentName)}
       {...(href
         ? ({
             as: 'a',

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -5,6 +5,7 @@ import { listItem, type ListItemVariantProps } from '@styled-system/recipes';
 
 import type { IconProps } from '~/components/Icon/Icon';
 import type { IconNamesList } from '~/components/Icon/icons';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -148,6 +149,7 @@ export const ListItem = (props: ListItemProps) => {
 
   return (
     <Box
+      {...dsComponent('ListItem')}
       {...(href
         ? ({
             as: 'a',

--- a/src/components/List/ListItemGroup.tsx
+++ b/src/components/List/ListItemGroup.tsx
@@ -4,6 +4,7 @@ import {
   type ListItemGroupVariantProps,
 } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -60,7 +61,11 @@ export const ListItemGroup = (props: ListItemGroupProps) => {
 
   return (
     <ListProvider value={nestedContextValue}>
-      <Box className={cx(classes.wrapper, className)} {...otherProps}>
+      <Box
+        {...dsComponent('ListItemGroup')}
+        className={cx(classes.wrapper, className)}
+        {...otherProps}
+      >
         {label && (
           <Text as="div" className={classes.groupLabel}>
             {label}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { radio, type RadioVariantProps } from '@styled-system/recipes';
 
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -75,6 +76,7 @@ export const Radio = (props: RadioProps) => {
     input,
     indicator,
     radioBg,
+    'data-ds-component': dsComponentName,
     ...rest
   } = props;
   const disabled = disabledProp ?? fieldContext?.disabled;
@@ -91,6 +93,7 @@ export const Radio = (props: RadioProps) => {
 
   return (
     <Box
+      {...dsComponent('Radio', dsComponentName)}
       className={cx(classes.container, className)}
       {...(error && { 'data-error': true })}
       {...(invalid && { 'data-invalid': true })}

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -1,5 +1,7 @@
 import { type ReactNode, useCallback, useMemo, useState } from 'react';
 
+import { dsComponent } from '~/utils/dsComponent';
+
 import { Box, type BoxProps } from '../Box';
 
 import { RadioGroupContext } from './RadioGroupContext';
@@ -80,6 +82,7 @@ export const RadioGroup = (props: RadioGroupProps) => {
   return (
     <RadioGroupContext.Provider value={contextValue}>
       <Box
+        {...dsComponent('RadioGroup')}
         role="radiogroup"
         aria-label={label}
         aria-labelledby={id ? `${id}-label` : undefined}

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -7,6 +7,7 @@ import {
 } from '@styled-system/recipes';
 
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Label } from '../Label/Label';
@@ -86,6 +87,7 @@ export const RadioInput = (props: RadioInputProps) => {
 
   return (
     <Label
+      {...dsComponent('RadioInput')}
       className={cx(radioInput(), className)}
       htmlFor={resolvedId}
       disabled={disabled}

--- a/src/components/SegmentedInputs/SegmentedDate.tsx
+++ b/src/components/SegmentedInputs/SegmentedDate.tsx
@@ -7,6 +7,7 @@ import type {
   DateFormat,
   DateValue,
 } from '~/components/DateTime/helpers/types';
+import { dsComponent } from '~/utils/dsComponent';
 
 import { SegmentedInput } from './SegmentedInput';
 
@@ -187,6 +188,7 @@ export const SegmentedDate = (props: SegmentedDateProps) => {
 
   return (
     <SegmentedInput
+      {...dsComponent('SegmentedDate')}
       {...rest}
       items={items}
       label={label}

--- a/src/components/SegmentedInputs/SegmentedInput.tsx
+++ b/src/components/SegmentedInputs/SegmentedInput.tsx
@@ -18,6 +18,7 @@ import {
 
 import { Box, type BoxProps } from '~/components/Box';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import {
@@ -266,6 +267,7 @@ export const SegmentedInput = (props: SegmentedInputProps) => {
 
   return (
     <Box
+      {...dsComponent('SegmentedInput')}
       ref={ref}
       className={cx(classes.root, className)}
       role="group"

--- a/src/components/SegmentedInputs/SegmentedTime.tsx
+++ b/src/components/SegmentedInputs/SegmentedTime.tsx
@@ -9,6 +9,7 @@ import type {
   TimeFormat,
   TimeValue,
 } from '~/components/DateTime/helpers/types';
+import { dsComponent } from '~/utils/dsComponent';
 
 import { SegmentedInput } from './SegmentedInput';
 
@@ -194,6 +195,7 @@ export const SegmentedTime = (props: SegmentedTimeProps) => {
 
   return (
     <SegmentedInput
+      {...dsComponent('SegmentedTime')}
       {...rest}
       items={items}
       label={label}

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { skeleton } from '@styled-system/recipes';
 
 import { Box, type BoxProps } from '~/components/Box';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Supported placeholder shapes for {@link Skeleton}. */
@@ -70,6 +71,7 @@ export const Skeleton = (props: SkeletonProps) => {
 
   return (
     <Box
+      {...dsComponent('Skeleton')}
       as={component}
       width={width as BoxProps['width']}
       height={height as BoxProps['height']}

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -2,6 +2,7 @@ import { cx } from '@styled-system/css';
 import { spinner, type SpinnerVariantProps } from '@styled-system/recipes';
 
 import { useSlotContext } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -44,7 +45,11 @@ export const Spinner = (props: SpinnerProps) => {
   });
 
   return (
-    <Box className={cx(classes.container, className)} {...otherProps}>
+    <Box
+      {...dsComponent('Spinner')}
+      className={cx(classes.container, className)}
+      {...otherProps}
+    >
       <Icon
         name="spinner"
         className={classes.spinnerSvg}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@styled-system/css';
 import { tag, type TagVariantProps } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -42,6 +43,7 @@ export const Tag = (props: TagProps) => {
 
   return (
     <Box
+      {...dsComponent('Tag')}
       className={cx(
         tag({
           variant,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,6 +5,7 @@ import { cx } from '@styled-system/css';
 import { text, type TextVariantProps } from '@styled-system/recipes';
 
 import { Box, type BoxProps } from '~/components/Box';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Props accepted by {@link Text}. */
@@ -54,6 +55,7 @@ export const Text = (props: TextProps) => {
 
   return (
     <Box
+      {...dsComponent('Text')}
       as={as}
       textStyle={textStyle}
       role={role}

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,3 +1,5 @@
+import { expect, within } from '@storybook/test';
+
 import { Grid, VStack, Wrap, HStack } from '@styled-system/jsx';
 
 import { Badge } from '../Badge';
@@ -543,6 +545,41 @@ export const SearchInput: Story = {
       />
     </Wrap>
   ),
+  parameters: { controls: { disable: true } },
+};
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <VStack alignItems="start" gap="8">
+      <TextInput name="ds-default" aria-label="Default input" />
+      <TextInput
+        name="ds-override"
+        aria-label="Overridden input"
+        data-ds-component="SearchField"
+      />
+    </VStack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // TextInput forwards rest props to the native input, so the attribute is
+    // applied to the container root and must not leak onto the input.
+    const defaultInput = canvas.getByLabelText('Default input');
+    expect(defaultInput).not.toHaveAttribute('data-ds-component');
+    expect(defaultInput.parentElement).toHaveAttribute(
+      'data-ds-component',
+      'TextInput',
+    );
+
+    // An explicit value lands on the root, not on the native input.
+    const overriddenInput = canvas.getByLabelText('Overridden input');
+    expect(overriddenInput).not.toHaveAttribute('data-ds-component');
+    expect(overriddenInput.parentElement).toHaveAttribute(
+      'data-ds-component',
+      'SearchField',
+    );
+  },
   parameters: { controls: { disable: true } },
 };
 

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -8,6 +8,7 @@ import { Icon, type IconNamesList } from '~/components/Icon';
 import { IconButton } from '~/components/IconButton';
 import { useFieldContext } from '~/system/context/FieldContext';
 import { SlotContext, type SlotPlacement } from '~/system/context/SlotContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -94,6 +95,7 @@ export const TextInput = (props: TextInputProps) => {
     size: sizeProp,
     autoSize = false,
     autoComplete = 'off',
+    'data-ds-component': dsComponentName,
     ...rest
   } = props;
   const size = sizeProp ?? fieldContext?.size;
@@ -166,6 +168,7 @@ export const TextInput = (props: TextInputProps) => {
 
   return (
     <Box
+      {...dsComponent('TextInput', dsComponentName)}
       className={cx(classes.container, className)}
       aria-disabled={disabled}
       data-disabled={disabled || undefined}

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -3,6 +3,7 @@ import { textarea, type TextareaVariantProps } from '@styled-system/recipes';
 
 import { Box, type BoxProps } from '~/components/Box';
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 /** Props for {@link Textarea}, a multi-line native text input. */
@@ -55,6 +56,7 @@ export const Textarea = (props: TextareaProps) => {
   const [className, otherProps] = splitProps(rest);
   return (
     <Box
+      {...dsComponent('Textarea')}
       as="textarea"
       id={id}
       name={name}

--- a/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,5 +1,6 @@
 import { IconButton } from '~/components/IconButton';
 import { useTheme } from '~/system/context';
+import { dsComponent } from '~/utils/dsComponent';
 
 /**
  * Renders an icon-only control that toggles the nearest theme provider between
@@ -22,6 +23,7 @@ export const ThemeSwitcher = () => {
 
   return (
     <IconButton
+      {...dsComponent('ThemeSwitcher')}
       variant="ghost"
       altText={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
       onClick={toggleTheme}

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -4,6 +4,7 @@ import { cx } from '@styled-system/css';
 import { toggle, type ToggleVariantProps } from '@styled-system/recipes';
 
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -75,6 +76,7 @@ export const Toggle = (props: ToggleProps) => {
     container,
     input,
     indicator,
+    'data-ds-component': dsComponentName,
     ...rest
   } = props;
   const disabled = disabledProp ?? fieldContext?.disabled;
@@ -90,6 +92,7 @@ export const Toggle = (props: ToggleProps) => {
 
   return (
     <Box
+      {...dsComponent('Toggle', dsComponentName)}
       className={cx(classes.container, className)}
       {...(error && { 'data-error': true })}
       {...(invalid && { 'data-invalid': true })}

--- a/src/components/ToggleInput/ToggleInput.tsx
+++ b/src/components/ToggleInput/ToggleInput.tsx
@@ -7,6 +7,7 @@ import {
 } from '@styled-system/recipes';
 
 import { useFieldContext } from '~/system/context/FieldContext';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { type BoxProps } from '../Box';
@@ -67,6 +68,7 @@ export const ToggleInput = (props: ToggleInputProps) => {
   const resolvedId = id ?? generatedId;
   return (
     <Label
+      {...dsComponent('ToggleInput')}
       className={cx(toggleInput({}), className)}
       htmlFor={resolvedId}
       error={error}

--- a/src/utils/dsComponent.ts
+++ b/src/utils/dsComponent.ts
@@ -1,0 +1,44 @@
+/**
+ * Attribute name that identifies which design-system component rendered a DOM
+ * element. Always lowercase and hyphenated; HTML lowercases attribute names, so
+ * a camelCase spelling would silently produce a different attribute.
+ */
+export const DS_COMPONENT_ATTRIBUTE = 'data-ds-component';
+
+/** Attribute record applied to a design-system component's root element. */
+export type DsComponentAttribute = {
+  'data-ds-component': string;
+};
+
+/**
+ * Returns the `data-ds-component` attribute for a component's root element.
+ *
+ * Spread the result as the first attribute on the root element so a
+ * consumer-supplied `data-ds-component` in the component's rest props still
+ * wins. When rest props are forwarded to a nested element instead of the root,
+ * pull `data-ds-component` out of the props first and pass it as `override` so
+ * the explicit value lands on the root and does not leak onto the inner
+ * element.
+ *
+ * @example
+ * ```tsx
+ * // Rest props are spread on the root: ordering handles the override.
+ * <Box {...dsComponent('Badge')} className={classes.root} {...otherProps} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Rest props are forwarded to a nested control: pass the override through.
+ * const { 'data-ds-component': dsComponentName, ...rest } = props;
+ *
+ * <Box {...dsComponent('Checkbox', dsComponentName)}>
+ *   <Box as="input" {...otherProps} />
+ * </Box>;
+ * ```
+ */
+export const dsComponent = (
+  name: string,
+  override?: string,
+): DsComponentAttribute => ({
+  [DS_COMPONENT_ATTRIBUTE]: override ?? name,
+});


### PR DESCRIPTION
Adds a `data-ds-component` attribute to component roots so the ERP front end can identify design-system components in the DOM without relying on class names or test ids.

This is the base of the front-end instrumentation work — the attribute is the anchor that behavior logging and automated tests both key off of.

## What's here

- **New:** `src/utils/dsComponent.ts` — helper that resolves the attribute value from a component's display name.
- Applies `data-ds-component` on the root element of the component set (48 files, +261/−6).
- Story coverage added for `TextInput`.

## Notes

- Additive only — no API changes, no breaking changes.
- Stacked below https://github.com/Cetec-ERP/Cetec-Design-System/pull/184, which builds `data-ds-part` and cross-portal chain resolution on top of this.

## Verification

Run locally on the branch tip:

| Check | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run build` | ✅ pass (exit 0, 341 modules, d.ts rollup clean) |
| `npm run lint` | ✅ pass (exit 0) |
| Storybook play stories | ⚠️ not run |

CI on this PR is green across `Validate`, `Validate PR title`, and `deploy-pr-preview`.

## Still to confirm

- Attribute naming (`data-ds-component`) is not yet locked — it's one of the open decisions in the instrumentation taxonomy. Easy to rename now, harder once consumers key off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
