### PR TITLE
feat(minor): emit data-ds-part and resolve interaction chains across portals

### DIFF
--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -623,3 +623,59 @@ export const TestIdReachesPortaledListbox: Story = {
   },
   parameters: { controls: { disable: true } },
 };
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <Box display="flex" flexDirection="column" gap="8" w="sm">
+      <Autocomplete data-testid="ds-default" aria-label="Default technology">
+        {renderOptions()}
+      </Autocomplete>
+      <Autocomplete
+        data-testid="ds-override"
+        data-ds-component="TechnologyPicker"
+        aria-label="Overridden technology"
+      >
+        {renderOptions()}
+      </Autocomplete>
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+
+    // Emitted automatically on the root, without an author opting in.
+    const root = canvas.getByTestId('ds-default');
+    await expect(root).toHaveAttribute('data-ds-component', 'Autocomplete');
+
+    // The combobox input is an inner part of the root, so it stays unmarked.
+    const input = canvas.getByRole('combobox', { name: 'Default technology' });
+    await expect(input).toHaveAttribute('data-ds-part', 'trigger');
+    await expect(input).not.toHaveAttribute('data-ds-component');
+
+    // An explicitly passed value wins, still on the root and not the input.
+    const overriddenRoot = canvas.getByTestId('ds-override');
+    await expect(overriddenRoot).toHaveAttribute(
+      'data-ds-component',
+      'TechnologyPicker',
+    );
+    await expect(
+      canvas.getByRole('combobox', { name: 'Overridden technology' }),
+    ).not.toHaveAttribute('data-ds-component');
+
+    // The portaled listbox is not the Autocomplete root either.
+    await userEvent.click(input);
+
+    const listbox = await screen.findByRole('listbox');
+
+    await expect(listbox).not.toHaveAttribute(
+      'data-ds-component',
+      'Autocomplete',
+    );
+    await expect(listbox).not.toHaveAttribute(
+      'data-ds-component',
+      'TechnologyPicker',
+    );
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -597,15 +597,28 @@ export const TestIdReachesPortaledListbox: Story = {
     await expect(root).toContainElement(input);
     await expect(input).not.toHaveAttribute('data-testid');
 
+    // The input keeps a stable query handle through `data-ds-part`, which the
+    // component emits on its own. It marks the trigger only, never the root.
+    await expect(input).toHaveAttribute('data-ds-part', 'trigger');
+    await expect(root).not.toHaveAttribute('data-ds-part');
+
     await userEvent.click(input);
 
     const listbox = await screen.findByRole('listbox');
 
     // The listbox is portaled out of the root, so only the chain connects them.
     await expect(root.contains(listbox)).toBe(false);
-    await expect(listbox.closest('[data-ds-chain]')).toHaveAttribute(
+
+    const chainRoot = listbox.closest('[data-ds-chain]');
+
+    // The chain is built from `data-testid` alone, so the trigger's
+    // `data-ds-part` contributes no node to it.
+    await expect(chainRoot).toHaveAttribute(
       'data-ds-chain',
       'filters>technology',
+    );
+    await expect(chainRoot?.getAttribute('data-ds-chain')).not.toContain(
+      'trigger',
     );
   },
   parameters: { controls: { disable: true } },

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -574,3 +574,39 @@ export const KeyboardTokenEditing: Story = {
   },
   parameters: { controls: { disable: true } },
 };
+
+export const TestIdReachesPortaledListbox: Story = {
+  name: 'Ex: Test Id Reaches The Listbox',
+  render: () => (
+    <Box w="sm" data-testid="filters">
+      <Autocomplete data-testid="technology" aria-label="Technology">
+        {renderOptions()}
+      </Autocomplete>
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+
+    // The test id is written on the root, not on the combobox input, so the
+    // chain scope it opens encloses the portal the input only sits beside.
+    const root = canvas.getByTestId('technology');
+    const input = canvas.getByRole('combobox');
+
+    await expect(root).not.toBe(input);
+    await expect(root).toContainElement(input);
+    await expect(input).not.toHaveAttribute('data-testid');
+
+    await userEvent.click(input);
+
+    const listbox = await screen.findByRole('listbox');
+
+    // The listbox is portaled out of the root, so only the chain connects them.
+    await expect(root.contains(listbox)).toBe(false);
+    await expect(listbox.closest('[data-ds-chain]')).toHaveAttribute(
+      'data-ds-chain',
+      'filters>technology',
+    );
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -10,6 +10,7 @@ import { cx } from '@styled-system/css';
 import type { AutocompleteVariantProps } from '@styled-system/recipes';
 
 import type { MenuDensity } from '~/components/Menu';
+import { dsComponent } from '~/utils/dsComponent';
 import { dsPart } from '~/utils/dsPart';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -281,6 +282,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
 
   return (
     <Box
+      {...dsComponent('Autocomplete')}
       ref={rootRef}
       className={cx(classes.root, className)}
       data-disabled={disabled || undefined}

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -10,6 +10,7 @@ import { cx } from '@styled-system/css';
 import type { AutocompleteVariantProps } from '@styled-system/recipes';
 
 import type { MenuDensity } from '~/components/Menu';
+import { dsPart } from '~/utils/dsPart';
 
 import { Box, type BoxProps } from '../Box/Box';
 import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
@@ -341,8 +342,16 @@ export const Autocomplete = (props: AutocompleteProps) => {
             </Box>
           )}
 
+          {/*
+            `data-ds-part` gives the combobox input a stable query handle;
+            `data-testid` stays on the root so the chain scope it opens encloses
+            the portaled listbox. It is internal instrumentation, not a
+            supported prop, and the chain reads `data-testid` only, so it adds
+            no chain node.
+          */}
           <Box
             as="input"
+            {...dsPart('trigger')}
             id={inputId}
             ref={inputRef}
             type="text"

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -12,6 +12,7 @@ import type { AutocompleteVariantProps } from '@styled-system/recipes';
 import type { MenuDensity } from '~/components/Menu';
 
 import { Box, type BoxProps } from '../Box/Box';
+import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
 import { Spinner } from '../Spinner/Spinner';
 
 import { AutocompleteListbox } from './AutocompleteListbox';
@@ -395,38 +396,40 @@ export const Autocomplete = (props: AutocompleteProps) => {
 
       {isOpen && !disabled && !readOnly && (
         <FloatingPortal>
-          <FloatingFocusManager
-            context={floating.context}
-            modal={false}
-            initialFocus={-1}
-          >
-            <AutocompleteListbox
-              activeIndex={activeIndex}
-              baseId={baseId}
-              density={density}
-              floatingProps={getFloatingProps() as Record<string, unknown>}
-              floatingRef={setFloatingRef}
-              floatingStyles={floating.floatingStyles}
-              getItemProps={(itemProps: HTMLProps<HTMLElement>) =>
-                getItemProps(itemProps) as Record<string, unknown>
-              }
-              items={navigationItems}
-              listboxClassName={classes.listbox}
-              listboxId={listboxId}
-              loading={loading}
-              loadingMore={loadingMore}
-              loadingText={loadingText}
-              multiple={Boolean(multiple)}
-              noOptionsText={noOptionsText}
-              onScroll={handleListScroll}
-              onSelect={handleOptionSelect}
-              query={currentInputValue.trim()}
-              selectedValues={selectedValues}
-              setItemRef={setItemRef}
-              statusClassName={classes.status}
-              value={currentValue}
-            />
-          </FloatingFocusManager>
+          <DsChainPortalRoot>
+            <FloatingFocusManager
+              context={floating.context}
+              modal={false}
+              initialFocus={-1}
+            >
+              <AutocompleteListbox
+                activeIndex={activeIndex}
+                baseId={baseId}
+                density={density}
+                floatingProps={getFloatingProps() as Record<string, unknown>}
+                floatingRef={setFloatingRef}
+                floatingStyles={floating.floatingStyles}
+                getItemProps={(itemProps: HTMLProps<HTMLElement>) =>
+                  getItemProps(itemProps) as Record<string, unknown>
+                }
+                items={navigationItems}
+                listboxClassName={classes.listbox}
+                listboxId={listboxId}
+                loading={loading}
+                loadingMore={loadingMore}
+                loadingText={loadingText}
+                multiple={Boolean(multiple)}
+                noOptionsText={noOptionsText}
+                onScroll={handleListScroll}
+                onSelect={handleOptionSelect}
+                query={currentInputValue.trim()}
+                selectedValues={selectedValues}
+                setItemRef={setItemRef}
+                statusClassName={classes.status}
+                value={currentValue}
+              />
+            </FloatingFocusManager>
+          </DsChainPortalRoot>
         </FloatingPortal>
       )}
     </Box>

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -8,6 +8,7 @@ import { cx } from '@styled-system/css';
 import { box, type BoxVariantProps } from '@styled-system/recipes';
 import type { SystemStyleObject } from '@styled-system/types';
 
+import { DsChainScope } from '~/components/DsChainScope';
 import { splitProps } from '~/utils/splitProps';
 
 type AsProp<T extends ElementType> = {
@@ -61,10 +62,23 @@ export const Box = <T extends ElementType = 'div'>(props: BoxProps<T>) => {
   const comboClassName = cx(box({}), className);
 
   // Runtime render happens via React.createElement so `as` can be dynamic.
-  return createElement(Component, {
+  const element = createElement(Component, {
     className: comboClassName,
     ...otherProps,
   });
+
+  // Instrumentation is opt-in by `data-testid` presence, not by component
+  // identity. Box sits on every render path in the system, so the untagged case
+  // must cost nothing: one property read and an early return. No hook call, no
+  // context subscription, no array, no object literal, no extra element.
+  // Box itself calls no hooks, so branching on a prop here cannot desynchronize
+  // hook order; the scope is a separate component that owns its own hooks.
+  const testId = otherProps['data-testid'];
+  if (typeof testId !== 'string' || testId.length === 0) {
+    return element;
+  }
+
+  return <DsChainScope testId={testId}>{element}</DsChainScope>;
 };
 
 // React 19+: ComponentPropsWithRef<ElementType> is recommended as refs are now passed as props in function components.

--- a/src/components/Code/Code.stories.tsx
+++ b/src/components/Code/Code.stories.tsx
@@ -1,3 +1,5 @@
+import { expect, within } from '@storybook/test';
+
 import { Box } from '../Box';
 import { Text } from '../Text';
 
@@ -43,6 +45,43 @@ export function SaveAction() {
 }`}</Pre>
     </Box>
   ),
+  parameters: { controls: { disable: true } },
+};
+
+export const PreRootProps: Story = {
+  name: 'Test: Pre root props',
+  render: () => (
+    <Box maxW="2xl">
+      <Pre
+        lang="tsx"
+        id="pre-root"
+        data-testid="pre-root"
+        data-ds-component="CodeBlock"
+      >
+        {'const ready = true;'}
+      </Pre>
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pre = canvas.getByTestId('pre-root');
+    const code = pre.querySelector('code');
+
+    if (!(code instanceof HTMLElement)) {
+      throw new Error('Pre should render a nested code element.');
+    }
+
+    // Consumer props land on the root `pre` only.
+    expect(pre).toHaveAttribute('id', 'pre-root');
+    expect(pre).toHaveAttribute('data-ds-component', 'CodeBlock');
+
+    // The nested `code` keeps its own identity and does not receive the
+    // consumer props spread onto the root.
+    expect(code).not.toHaveAttribute('id');
+    expect(code).not.toHaveAttribute('data-testid');
+    expect(code).toHaveAttribute('data-ds-component', 'Code');
+    expect(code).toHaveAttribute('lang', 'tsx');
+  },
   parameters: { controls: { disable: true } },
 };
 

--- a/src/components/Code/Pre.tsx
+++ b/src/components/Code/Pre.tsx
@@ -14,7 +14,7 @@ type PreOwnProps = {
   children: string | ReactNode;
   /** Language metadata forwarded to the nested `Code` element. */
   lang?: string;
-  /** Element override forwarded through the rendered containers. */
+  /** Element override for the rendered `pre` container. */
   as?: string;
 };
 
@@ -42,7 +42,10 @@ export const Pre = (props: PreProps) => {
       className={cx(pre({}), className)}
       {...otherProps}
     >
-      <Code lang={lang} slot="react" bg="transparent" {...otherProps}>
+      {/* Consumer props stay on the root `pre`; the nested `Code` owns its own
+          attributes so values like `id` and `data-ds-component` are not
+          duplicated onto two elements. */}
+      <Code lang={lang} slot="react" bg="transparent">
         {children}
       </Code>
     </Box>

--- a/src/components/DateTime/menus/DateMenu.tsx
+++ b/src/components/DateTime/menus/DateMenu.tsx
@@ -1,6 +1,7 @@
 import { Box } from '~/components/Box';
 import { Calendar } from '~/components/Calendar';
 import { Menu, type MenuProps } from '~/components/Menu';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 import { useControllableState } from '~/utils/useControllableState';
 
@@ -79,6 +80,7 @@ export const DateMenu = (props: DateMenuProps) => {
 
   return (
     <Menu
+      {...dsComponent('DateMenu')}
       className={className}
       {...otherProps}
       trigger={trigger}

--- a/src/components/DateTime/menus/DateRangeMenu.tsx
+++ b/src/components/DateTime/menus/DateRangeMenu.tsx
@@ -7,6 +7,7 @@ import { Button } from '~/components/Button';
 import { Calendar } from '~/components/Calendar';
 import { Divider } from '~/components/Divider';
 import { Menu, type MenuProps } from '~/components/Menu';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 import { useControllableState } from '~/utils/useControllableState';
 
@@ -156,6 +157,7 @@ export const DateRangeMenu = (props: DateRangeMenuProps) => {
 
   return (
     <Menu
+      {...dsComponent('DateRangeMenu')}
       className={className}
       {...otherProps}
       trigger={trigger}

--- a/src/components/DateTime/menus/DateTimeMenu.tsx
+++ b/src/components/DateTime/menus/DateTimeMenu.tsx
@@ -15,6 +15,7 @@ import { Calendar } from '~/components/Calendar';
 import { Divider } from '~/components/Divider';
 import { List, ListItem } from '~/components/List';
 import { Menu, type MenuProps } from '~/components/Menu';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 import { useControllableState } from '~/utils/useControllableState';
 
@@ -263,6 +264,7 @@ export const DateTimeMenu = (props: DateTimeMenuProps) => {
 
   return (
     <Menu
+      {...dsComponent('DateTimeMenu')}
       className={className}
       {...otherProps}
       trigger={trigger}

--- a/src/components/DateTime/menus/TimeMenu.tsx
+++ b/src/components/DateTime/menus/TimeMenu.tsx
@@ -5,6 +5,7 @@ import { timeMenus } from '@styled-system/recipes';
 import { Box } from '~/components/Box';
 import { List, ListItem } from '~/components/List';
 import { Menu, type MenuProps } from '~/components/Menu';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 import { useControllableState } from '~/utils/useControllableState';
 
@@ -168,6 +169,7 @@ export const TimeMenu = (props: TimeMenuProps) => {
 
   return (
     <Menu
+      {...dsComponent('TimeMenu')}
       className={className}
       {...otherProps}
       trigger={trigger}

--- a/src/components/DateTime/menus/TimeRangeMenu.tsx
+++ b/src/components/DateTime/menus/TimeRangeMenu.tsx
@@ -7,6 +7,7 @@ import { Button } from '~/components/Button';
 import { Divider } from '~/components/Divider';
 import { List, ListItem } from '~/components/List';
 import { Menu, type MenuProps } from '~/components/Menu';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 import { useControllableState } from '~/utils/useControllableState';
 
@@ -280,6 +281,7 @@ export const TimeRangeMenu = (props: TimeRangeMenuProps) => {
 
   return (
     <Menu
+      {...dsComponent('TimeRangeMenu')}
       className={className}
       {...otherProps}
       trigger={trigger}

--- a/src/components/DsChainScope/DsChainPortalRoot.tsx
+++ b/src/components/DsChainScope/DsChainPortalRoot.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+import { dsChainValue, useDsChain } from '~/utils/dsChain';
+
+type DsChainPortalRootProps = {
+  /** Portal contents that need DOM ancestry back to the opening subtree. */
+  children?: ReactNode;
+};
+
+/**
+ * Wraps portal contents in an element stamped with the resolved chain.
+ *
+ * Internal. Render it as the outermost child of a `FloatingPortal` so the
+ * chain is read at the portal's position in the React tree, which is where the
+ * opening component sits, rather than at the component function's own
+ * position. Reading it in the component body instead would miss any scope the
+ * component's own root `Box` opened for its subtree.
+ *
+ * The attribute is written during render, never from an effect: portal content
+ * mounts late, and an effect-stamped attribute can lose the race against a
+ * click that lands immediately after paint.
+ *
+ * The wrapper is an unstyled, statically positioned `div`. Every floating
+ * element it wraps is absolutely or fixed positioned, so it stays out of flow
+ * and the wrapper contributes no layout box of its own.
+ */
+export const DsChainPortalRoot = ({ children }: DsChainPortalRootProps) => {
+  const chain = useDsChain();
+
+  return <div data-ds-chain={dsChainValue(chain)}>{children}</div>;
+};

--- a/src/components/DsChainScope/DsChainPortalRoot.tsx
+++ b/src/components/DsChainScope/DsChainPortalRoot.tsx
@@ -27,5 +27,15 @@ type DsChainPortalRootProps = {
 export const DsChainPortalRoot = ({ children }: DsChainPortalRootProps) => {
   const chain = useDsChain();
 
-  return <div data-ds-chain={dsChainValue(chain)}>{children}</div>;
+  return (
+    // The marker is unconditional; the chain value is not. An empty chain emits
+    // no `data-ds-chain`, so without the marker an untagged portal is
+    // indistinguishable from an ordinary element and a consumer walking up the
+    // DOM continues past it into `document.body` — producing a chain from
+    // whatever it finds there, with no error. The marker makes "portal
+    // boundary, chain resolved to nothing" a state a reader can detect.
+    <div data-ds-portal-root="" data-ds-chain={dsChainValue(chain)}>
+      {children}
+    </div>
+  );
 };

--- a/src/components/DsChainScope/DsChainScope.stories.tsx
+++ b/src/components/DsChainScope/DsChainScope.stories.tsx
@@ -133,6 +133,42 @@ export const ChainKeepsTheNearestFive: Story = {
   parameters: { controls: { disable: true } },
 };
 
+export const RepeatedNodeIsCollapsed: Story = {
+  name: 'Chain: A Repeated Node Is Collapsed',
+  render: () => (
+    <Box data-testid="page">
+      {/*
+        The scope and the element carry the same id. A component that opens a
+        scope above its root and also writes the id on an inner element
+        produces this, and so does a consumer wrapping a tagged component.
+      */}
+      <DsChainScope testId="status">
+        <Box data-testid="status">
+          <ChainProbe name="collapsed" />
+        </Box>
+      </DsChainScope>
+
+      {/* Only the innermost node is compared, so real nesting still counts. */}
+      <Box data-testid="grid">
+        <Box data-testid="row">
+          <Box data-testid="grid">
+            <ChainProbe name="nested" />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    // Not `page>status>status` — the repeat carries nothing and would spend
+    // one of five slots.
+    expect(readProbe(canvasElement, 'collapsed')).toBe('page>status');
+
+    // A grid inside a grid is real structure, so the repeat is kept.
+    expect(readProbe(canvasElement, 'nested')).toBe('page>grid>row>grid');
+  },
+  parameters: { controls: { disable: true } },
+};
+
 export const ScopeCoversRawDom: Story = {
   name: 'Ex: Scope Around Raw DOM',
   render: () => (
@@ -180,6 +216,41 @@ export const PortalStampsResolvedChain: Story = {
     const portalRoot = listbox.closest('[data-ds-chain]');
     expect(portalRoot).not.toBeNull();
     expect(portalRoot).toHaveAttribute('data-ds-chain', 'page>filters');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const PortalRootIsMarkedWithoutAChain: Story = {
+  name: 'Ex: Portal Boundary Is Findable With No Chain',
+  render: () => (
+    // Deliberately untagged: no ancestor carries a `data-testid`, which is the
+    // state of almost every screen before anyone tags it.
+    <Box>
+      <Select aria-label="Status" placeholder="Choose a status...">
+        <SelectOption value="draft" label="Draft" />
+        <SelectOption value="published" label="Published" />
+      </Select>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+    const trigger = canvas.getByRole('combobox', { name: /status/i });
+
+    trigger.focus();
+    await userEvent.keyboard('{ArrowDown}');
+
+    const listbox = await screen.findByRole('listbox');
+    const portalRoot = listbox.closest('[data-ds-portal-root]');
+
+    // The marker is unconditional, so the boundary is findable.
+    expect(portalRoot).not.toBeNull();
+
+    // The chain is not: an empty chain emits no attribute, so a reader can
+    // tell "resolved to nothing" from "never resolved". Without the marker
+    // this element would be an ordinary div and a walk-up would pass straight
+    // through it into `document.body`.
+    expect(portalRoot).not.toHaveAttribute('data-ds-chain');
   },
   parameters: { controls: { disable: true } },
 };

--- a/src/components/DsChainScope/DsChainScope.stories.tsx
+++ b/src/components/DsChainScope/DsChainScope.stories.tsx
@@ -1,0 +1,239 @@
+import { useState } from 'react';
+
+import { expect, userEvent, within } from '@storybook/test';
+
+import { useDsChain } from '~/utils/dsChain';
+
+import { Box } from '../Box';
+import { Button } from '../Button';
+import { Menu, MenuItem } from '../Menu';
+import { Modal, ModalBody, ModalHeader } from '../Modal';
+import { Select, SelectOption } from '../Select';
+import { Text } from '../Text';
+
+import { DsChainScope } from './DsChainScope';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+/**
+ * Reads the chain at its own position in the React tree and writes it to a
+ * queryable attribute. `data-probe` deliberately avoids `data-testid` so the
+ * probe itself never contributes a node to the chain it is reporting.
+ */
+const ChainProbe = ({ name }: { name: string }) => {
+  const chain = useDsChain();
+
+  return (
+    <Box
+      data-probe={name}
+      data-chain={chain.join('>')}
+      p="8"
+      borderWidth="1"
+      borderColor="border"
+      borderRadius="4"
+    >
+      <Text>
+        {name}: {chain.join('>') || '(empty)'}
+      </Text>
+    </Box>
+  );
+};
+
+const readProbe = (root: HTMLElement, name: string) =>
+  root.querySelector(`[data-probe="${name}"]`)?.getAttribute('data-chain');
+
+const meta = {
+  title: 'Components/DsChainScope',
+  component: DsChainScope,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Adds a test id to the interaction chain shared with a subtree. `Box` opens a scope automatically whenever it receives a `data-testid`, so this component is only needed around raw DOM that does not render through `Box`.',
+      },
+    },
+  },
+  args: {
+    testId: 'scope',
+  },
+} satisfies Meta<typeof DsChainScope>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <DsChainScope testId="order-table">
+      <DsChainScope testId="order-row">
+        <ChainProbe name="default" />
+      </DsChainScope>
+    </DsChainScope>
+  ),
+  parameters: { controls: { disable: true } },
+};
+
+export const ChainBuildsAcrossTaggedElements: Story = {
+  name: 'Chain: Tagged Ancestors Accumulate',
+  render: () => (
+    <Box display="grid" gap="12">
+      <ChainProbe name="untracked" />
+      <Box data-testid="page" display="grid" gap="12">
+        <ChainProbe name="page" />
+        {/* Untagged Box: present in the DOM, absent from the chain. */}
+        <Box display="grid" gap="12">
+          <ChainProbe name="untagged" />
+          <Box data-testid="panel" display="grid" gap="12">
+            <ChainProbe name="panel" />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    // A probe outside every scope reads the shared empty chain.
+    expect(readProbe(canvasElement, 'untracked')).toBe('');
+
+    // A tagged Box pushes its own `data-testid` for its subtree.
+    expect(readProbe(canvasElement, 'page')).toBe('page');
+
+    // An untagged Box between two tagged ones contributes nothing.
+    expect(readProbe(canvasElement, 'untagged')).toBe('page');
+
+    // Nested tags accumulate nearest-last.
+    expect(readProbe(canvasElement, 'panel')).toBe('page>panel');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const ChainKeepsTheNearestFive: Story = {
+  name: 'Chain: Depth Is Bounded At Five',
+  render: () => (
+    <Box data-testid="one">
+      <Box data-testid="two">
+        <Box data-testid="three">
+          <Box data-testid="four">
+            <Box data-testid="five">
+              <Box data-testid="six">
+                <Box data-testid="seven">
+                  <ChainProbe name="deep" />
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    // Seven tagged ancestors, nearest five retained.
+    expect(readProbe(canvasElement, 'deep')).toBe('three>four>five>six>seven');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const ScopeCoversRawDom: Story = {
+  name: 'Ex: Scope Around Raw DOM',
+  render: () => (
+    <Box data-testid="order-table">
+      {/* A raw element never reaches Box, so the scope supplies the node. */}
+      <DsChainScope testId="order-row">
+        <div data-testid="order-row">
+          <ChainProbe name="raw" />
+        </div>
+      </DsChainScope>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    expect(readProbe(canvasElement, 'raw')).toBe('order-table>order-row');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const PortalStampsResolvedChain: Story = {
+  name: 'Ex: Portaled Listbox Carries The Chain',
+  render: () => (
+    <Box data-testid="page">
+      <Box data-testid="filters">
+        <Select aria-label="Status" placeholder="Choose a status...">
+          <SelectOption value="draft" label="Draft" />
+          <SelectOption value="published" label="Published" />
+        </Select>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+    const trigger = canvas.getByRole('combobox', { name: /status/i });
+
+    trigger.focus();
+    await userEvent.keyboard('{ArrowDown}');
+
+    const listbox = await screen.findByRole('listbox');
+
+    // The problem this solves: the listbox has no DOM ancestry to its opener.
+    expect(trigger.contains(listbox)).toBe(false);
+
+    // The portal root carries the chain from the opener's React-tree position.
+    const portalRoot = listbox.closest('[data-ds-chain]');
+    expect(portalRoot).not.toBeNull();
+    expect(portalRoot).toHaveAttribute('data-ds-chain', 'page>filters');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+const NestedPortalsExample = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box data-testid="page">
+      <Button onClick={() => setOpen(true)}>Open modal</Button>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalHeader>Assign owner</ModalHeader>
+        <ModalBody>
+          <Box data-testid="owner-field">
+            <Menu
+              trigger={<Button iconAfter="caret-down">Choose owner</Button>}
+            >
+              <MenuItem label="Ada Lovelace" />
+              <MenuItem label="Grace Hopper" />
+            </Menu>
+          </Box>
+        </ModalBody>
+      </Modal>
+    </Box>
+  );
+};
+
+export const NestedPortalsCompose: Story = {
+  name: 'Ex: Portal Inside A Portal',
+  render: () => <NestedPortalsExample />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: /open modal/i }));
+
+    const modalRoot = (await screen.findByText('Assign owner')).closest(
+      '[data-ds-chain]',
+    );
+    expect(modalRoot).toHaveAttribute('data-ds-chain', 'page');
+
+    await userEvent.click(screen.getByText('Choose owner'));
+
+    const menuRoot = (await screen.findByText('Ada Lovelace')).closest(
+      '[data-ds-chain]',
+    );
+
+    // The menu opened from inside the modal, and its chain continues past it.
+    expect(menuRoot).toHaveAttribute('data-ds-chain', 'page>owner-field');
+
+    // Both portals are siblings in the body, so the composition came from the
+    // React tree rather than from DOM containment.
+    expect(menuRoot).not.toBe(modalRoot);
+    expect(modalRoot?.contains(menuRoot ?? null)).toBe(false);
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/src/components/DsChainScope/DsChainScope.tsx
+++ b/src/components/DsChainScope/DsChainScope.tsx
@@ -1,0 +1,52 @@
+import { useMemo, type ReactNode } from 'react';
+
+import { DsChainContext, extendDsChain, useDsChain } from '~/utils/dsChain';
+
+/** Props accepted by {@link DsChainScope}. */
+export type DsChainScopeProps = {
+  /**
+   * `data-testid` value appended to the chain inherited by `children`. Match it
+   * to the `data-testid` written on the element this scope describes so the
+   * chain and the DOM agree.
+   */
+  testId: string;
+  /** Subtree that resolves the extended chain. */
+  children?: ReactNode;
+};
+
+/**
+ * Adds a test id to the interaction chain shared with a subtree.
+ *
+ * Design-system components pick this up automatically: `Box` opens a scope
+ * whenever it receives a `data-testid`, so anything rendered through the
+ * library already contributes. Reach for `DsChainScope` only around raw DOM
+ * that does not render through `Box` and still needs to appear in the chain,
+ * such as an application-owned wrapper element.
+ *
+ * The chain exists so portaled content can be attributed back to the subtree
+ * that opened it. A menu, modal, or tooltip renders into `document.body` and
+ * has no DOM ancestry to its opener, but React context follows the React tree
+ * through a portal, so the chain resolves correctly on either side.
+ *
+ * Renders no DOM of its own. The chain keeps the five nearest ids.
+ *
+ * @example
+ * ```tsx
+ * <DsChainScope testId="order-row">
+ *   <tr data-testid="order-row">{cells}</tr>
+ * </DsChainScope>
+ * ```
+ */
+export const DsChainScope = ({ testId, children }: DsChainScopeProps) => {
+  const parentChain = useDsChain();
+  // Memoized on the inherited chain and this id: an unrelated parent render
+  // must not hand descendants a new array identity and re-render every reader.
+  const chain = useMemo(
+    () => extendDsChain(parentChain, testId),
+    [parentChain, testId],
+  );
+
+  return (
+    <DsChainContext.Provider value={chain}>{children}</DsChainContext.Provider>
+  );
+};

--- a/src/components/DsChainScope/index.tsx
+++ b/src/components/DsChainScope/index.tsx
@@ -1,0 +1,1 @@
+export { DsChainScope, type DsChainScopeProps } from './DsChainScope';

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -44,6 +44,7 @@ import {
   createOverlayMiddleware,
   useOverlayFloating,
 } from '~/system/floating-ui/floating';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box } from '../Box/Box';
@@ -435,6 +436,7 @@ export const Menu = (props: MenuProps) => {
     <MenuRootProvider value={rootContextValue}>
       <MenuFilterProvider value={filterContextValue}>
         <Box
+          {...dsComponent('Menu')}
           ref={floating.refs.setFloating}
           className={cx(classes.wrapper, className)}
           {...getFloatingProps()}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -47,6 +47,7 @@ import {
 import { splitProps } from '~/utils/splitProps';
 
 import { Box } from '../Box/Box';
+import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
 import { Icon } from '../Icon/Icon';
 import { Text } from '../Text/Text';
 
@@ -667,22 +668,24 @@ export const Menu = (props: MenuProps) => {
         )}
         {isOpen && (
           <FloatingPortal>
-            <FloatingFocusManager
-              context={floating.context}
-              modal={false}
-              // Menubar composition: keep focus on the section trigger until the
-              // user arrows into the panel, so Left/Right can move between
-              // top-level menubar items while the dropdown is open (APG pattern).
-              // Default initialFocus=0 would move focus to the first menu row and
-              // swallow menubar navigation until a child is focused.
-              order={
-                onMenubarEdgeNavigate ? ['reference', 'content'] : undefined
-              }
-              initialFocus={triggerInteraction === 'focus' ? -1 : undefined}
-              returnFocus={triggerInteraction === 'focus' ? false : undefined}
-            >
-              {content}
-            </FloatingFocusManager>
+            <DsChainPortalRoot>
+              <FloatingFocusManager
+                context={floating.context}
+                modal={false}
+                // Menubar composition: keep focus on the section trigger until the
+                // user arrows into the panel, so Left/Right can move between
+                // top-level menubar items while the dropdown is open (APG pattern).
+                // Default initialFocus=0 would move focus to the first menu row and
+                // swallow menubar navigation until a child is focused.
+                order={
+                  onMenubarEdgeNavigate ? ['reference', 'content'] : undefined
+                }
+                initialFocus={triggerInteraction === 'focus' ? -1 : undefined}
+                returnFocus={triggerInteraction === 'focus' ? false : undefined}
+              >
+                {content}
+              </FloatingFocusManager>
+            </DsChainPortalRoot>
           </FloatingPortal>
         )}
       </FloatingNode>

--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -41,6 +41,7 @@ import { list, listItem as listItemRecipe, menu } from '@styled-system/recipes';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box } from '../Box/Box';
+import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
 import { Icon } from '../Icon/Icon';
 import { HighlightText } from '../List/HighlightText';
 import { Text } from '../Text/Text';
@@ -586,40 +587,42 @@ export const SubMenu = (props: SubMenuProps) => {
 
       {open && (
         <FloatingPortal>
-          <FloatingFocusManager
-            context={floating.context}
-            modal={false}
-            initialFocus={-1}
-            returnFocus={false}
-          >
-            <MenuFilterProvider value={nestedFilterContext}>
-              <MenuListProvider value={nestedListContext}>
-                <Box
-                  ref={floating.refs.setFloating}
-                  className={cx(classes.wrapper, contentClassName)}
-                  {...getFloatingProps({
-                    onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
-                      if (event.key === 'ArrowLeft') {
-                        event.preventDefault();
-                        setOpen(false);
-                        queueMicrotask(() =>
-                          subMenuTriggerRef.current?.focus(),
-                        );
-                      }
-                    },
-                  })}
-                  style={floatingStyle}
-                >
-                  <FloatingList
-                    elementsRef={floatingListRef}
-                    labelsRef={labelsRef}
+          <DsChainPortalRoot>
+            <FloatingFocusManager
+              context={floating.context}
+              modal={false}
+              initialFocus={-1}
+              returnFocus={false}
+            >
+              <MenuFilterProvider value={nestedFilterContext}>
+                <MenuListProvider value={nestedListContext}>
+                  <Box
+                    ref={floating.refs.setFloating}
+                    className={cx(classes.wrapper, contentClassName)}
+                    {...getFloatingProps({
+                      onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+                        if (event.key === 'ArrowLeft') {
+                          event.preventDefault();
+                          setOpen(false);
+                          queueMicrotask(() =>
+                            subMenuTriggerRef.current?.focus(),
+                          );
+                        }
+                      },
+                    })}
+                    style={floatingStyle}
                   >
-                    <Box className={listClassName}>{children}</Box>
-                  </FloatingList>
-                </Box>
-              </MenuListProvider>
-            </MenuFilterProvider>
-          </FloatingFocusManager>
+                    <FloatingList
+                      elementsRef={floatingListRef}
+                      labelsRef={labelsRef}
+                    >
+                      <Box className={listClassName}>{children}</Box>
+                    </FloatingList>
+                  </Box>
+                </MenuListProvider>
+              </MenuFilterProvider>
+            </FloatingFocusManager>
+          </DsChainPortalRoot>
         </FloatingPortal>
       )}
     </FloatingNode>

--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -38,6 +38,7 @@ import {
 import { cx } from '@styled-system/css';
 import { list, listItem as listItemRecipe, menu } from '@styled-system/recipes';
 
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box } from '../Box/Box';
@@ -457,6 +458,7 @@ export const SubMenu = (props: SubMenuProps) => {
 
     return (
       <button
+        {...dsComponent('SubMenu')}
         {...menuItemHtmlProps}
         role="menuitem"
         aria-disabled={disabled}
@@ -522,6 +524,7 @@ export const SubMenu = (props: SubMenuProps) => {
   return (
     <FloatingNode id={nodeId}>
       <button
+        {...dsComponent('SubMenu')}
         {...menuItemHtmlProps}
         role="menuitem"
         aria-haspopup="menu"

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -22,6 +22,7 @@ import {
 } from '@styled-system/recipes';
 
 import { useOverlayFloating } from '~/system/floating-ui/floating';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -194,6 +195,7 @@ export const Modal = (props: ModalProps) => {
             />
             <FloatingFocusManager context={context} modal={true}>
               <Box
+                {...dsComponent('Modal')}
                 ref={refs.setFloating}
                 className={cx(classes.container, className)}
                 data-state={dataState}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -25,6 +25,7 @@ import { useOverlayFloating } from '~/system/floating-ui/floating';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
+import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
 
 import { ModalContext, type ModalContextValue } from './ModalContext';
 
@@ -180,31 +181,33 @@ export const Modal = (props: ModalProps) => {
   return (
     <ModalContext.Provider value={contextValue}>
       <FloatingPortal>
-        <Box className={classes.positionWrapper}>
-          <FloatingOverlay
-            lockScroll
-            className={classes.overlay}
-            data-state={dataState}
-            onClick={
-              preventOverlayClose ? undefined : () => onOpenChange(false)
-            }
-            aria-hidden="true"
-          />
-          <FloatingFocusManager context={context} modal={true}>
-            <Box
-              ref={refs.setFloating}
-              className={cx(classes.container, className)}
+        <DsChainPortalRoot>
+          <Box className={classes.positionWrapper}>
+            <FloatingOverlay
+              lockScroll
+              className={classes.overlay}
               data-state={dataState}
-              id={id}
-              role="dialog"
-              aria-modal="true"
-              {...(getFloatingProps() as Record<string, unknown>)}
-              {...otherProps}
-            >
-              {children}
-            </Box>
-          </FloatingFocusManager>
-        </Box>
+              onClick={
+                preventOverlayClose ? undefined : () => onOpenChange(false)
+              }
+              aria-hidden="true"
+            />
+            <FloatingFocusManager context={context} modal={true}>
+              <Box
+                ref={refs.setFloating}
+                className={cx(classes.container, className)}
+                data-state={dataState}
+                id={id}
+                role="dialog"
+                aria-modal="true"
+                {...(getFloatingProps() as Record<string, unknown>)}
+                {...otherProps}
+              >
+                {children}
+              </Box>
+            </FloatingFocusManager>
+          </Box>
+        </DsChainPortalRoot>
       </FloatingPortal>
     </ModalContext.Provider>
   );

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -416,3 +416,42 @@ export const A11yKeyboardInteraction: Story = {
   },
   parameters: { controls: { disable: true } },
 };
+
+export const TestIdReachesPortaledListbox: Story = {
+  name: 'Ex: Test Id Reaches The Listbox',
+  render: () => (
+    <Box w="xs" data-testid="filters">
+      <Select data-testid="status" placeholder="Choose an option...">
+        <SelectOption value="starter" label="Starter" />
+        <SelectOption value="growth" label="Growth" />
+        <SelectOption value="enterprise" label="Enterprise" />
+      </Select>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+
+    // The test id is written on the root, not on the combobox trigger, so the
+    // chain scope it opens encloses the portal the trigger only sits beside.
+    const root = canvas.getByTestId('status');
+    const trigger = canvas.getByRole('combobox');
+
+    expect(root).not.toBe(trigger);
+    expect(root).toContainElement(trigger);
+    expect(trigger).not.toHaveAttribute('data-testid');
+
+    trigger.focus();
+    await userEvent.keyboard('{ArrowDown}');
+
+    const listbox = await screen.findByRole('listbox');
+
+    // The listbox is portaled out of the root, so only the chain connects them.
+    expect(root.contains(listbox)).toBe(false);
+    expect(listbox.closest('[data-ds-chain]')).toHaveAttribute(
+      'data-ds-chain',
+      'filters>status',
+    );
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -463,3 +463,54 @@ export const TestIdReachesPortaledListbox: Story = {
   },
   parameters: { controls: { disable: true } },
 };
+
+export const DsComponentAttribute: Story = {
+  name: 'Test: data-ds-component',
+  render: () => (
+    <Box display="flex" flexDirection="column" gap="8" w="xs">
+      <Select data-testid="ds-default" placeholder="Choose an option...">
+        <SelectOption value="starter" label="Starter" />
+        <SelectOption value="growth" label="Growth" />
+      </Select>
+      <Select
+        data-testid="ds-override"
+        data-ds-component="StatusSelect"
+        placeholder="Choose an option..."
+      >
+        <SelectOption value="starter" label="Starter" />
+        <SelectOption value="growth" label="Growth" />
+      </Select>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+
+    // Emitted automatically on the root, without an author opting in.
+    const root = canvas.getByTestId('ds-default');
+    expect(root).toHaveAttribute('data-ds-component', 'Select');
+
+    // Select forwards its rest props to the combobox trigger, so the attribute
+    // is pulled out of them and must not leak onto the trigger.
+    const trigger = within(root).getByRole('combobox');
+    expect(trigger).toHaveAttribute('data-ds-part', 'trigger');
+    expect(trigger).not.toHaveAttribute('data-ds-component');
+
+    // An explicitly passed value wins, still on the root and not the trigger.
+    const overriddenRoot = canvas.getByTestId('ds-override');
+    expect(overriddenRoot).toHaveAttribute('data-ds-component', 'StatusSelect');
+    expect(within(overriddenRoot).getByRole('combobox')).not.toHaveAttribute(
+      'data-ds-component',
+    );
+
+    // The portaled listbox is `List`, so it never reports as the Select.
+    trigger.focus();
+    await userEvent.keyboard('{ArrowDown}');
+
+    const listbox = await screen.findByRole('listbox');
+
+    expect(listbox).not.toHaveAttribute('data-ds-component', 'Select');
+    expect(listbox).not.toHaveAttribute('data-ds-component', 'StatusSelect');
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -432,19 +432,20 @@ export const TestIdReachesPortaledListbox: Story = {
     const canvas = within(canvasElement);
     const screen = within(canvasElement.ownerDocument.body);
 
-    // The test id is written on the root, not on the combobox trigger, so the
-    // chain scope it opens encloses the portal the trigger only sits beside.
-    const root = canvas.getByTestId('status');
-    const trigger = canvas.getByRole('combobox');
+    // The test id stays on the combobox trigger — the element a test drives,
+    // and the element an existing selector already points at.
+    const trigger = canvas.getByTestId('status');
+    expect(trigger).toBe(canvas.getByRole('combobox'));
 
-    expect(root).not.toBe(trigger);
-    expect(root).toContainElement(trigger);
-    expect(trigger).not.toHaveAttribute('data-testid');
-
-    // The trigger keeps a stable query handle through `data-ds-part`, which the
-    // component emits on its own. It marks the trigger only, never the root.
+    // `data-ds-part` names the trigger for the collector. It is not a test
+    // handle and it never contributes a chain node.
     expect(trigger).toHaveAttribute('data-ds-part', 'trigger');
-    expect(root).not.toHaveAttribute('data-ds-part');
+
+    // The scope is opened above the root instead, because only the root
+    // encloses the portal's position in the React tree.
+    const root = trigger.closest('[data-ds-component="Select"]');
+    expect(root).not.toBe(trigger);
+    expect(root).not.toHaveAttribute('data-testid');
 
     trigger.focus();
     await userEvent.keyboard('{ArrowDown}');
@@ -452,14 +453,19 @@ export const TestIdReachesPortaledListbox: Story = {
     const listbox = await screen.findByRole('listbox');
 
     // The listbox is portaled out of the root, so only the chain connects them.
-    expect(root.contains(listbox)).toBe(false);
+    expect(root?.contains(listbox)).toBe(false);
 
-    const chainRoot = listbox.closest('[data-ds-chain]');
+    // Found by the unconditional marker, not by the chain value — the chain is
+    // absent whenever nothing upstream is tagged, and the boundary still needs
+    // to be findable then.
+    const portalRoot = listbox.closest('[data-ds-portal-root]');
+    expect(portalRoot).not.toBeNull();
 
-    // The chain is built from `data-testid` alone, so the trigger's
-    // `data-ds-part` contributes no node to it.
-    expect(chainRoot).toHaveAttribute('data-ds-chain', 'filters>status');
-    expect(chainRoot?.getAttribute('data-ds-chain')).not.toContain('trigger');
+    // The trigger's own `Box` opens a second scope with the same id; the
+    // repeat is collapsed, so the chain reads `filters>status`, not
+    // `filters>status>status`.
+    expect(portalRoot).toHaveAttribute('data-ds-chain', 'filters>status');
+    expect(portalRoot?.getAttribute('data-ds-chain')).not.toContain('trigger');
   },
   parameters: { controls: { disable: true } },
 };
@@ -486,22 +492,24 @@ export const DsComponentAttribute: Story = {
     const canvas = within(canvasElement);
     const screen = within(canvasElement.ownerDocument.body);
 
-    // Emitted automatically on the root, without an author opting in.
-    const root = canvas.getByTestId('ds-default');
-    expect(root).toHaveAttribute('data-ds-component', 'Select');
-
-    // Select forwards its rest props to the combobox trigger, so the attribute
-    // is pulled out of them and must not leak onto the trigger.
-    const trigger = within(root).getByRole('combobox');
+    // Select forwards its rest props to the combobox trigger, so the test id
+    // lands there and the root is reached from it.
+    const trigger = canvas.getByTestId('ds-default');
     expect(trigger).toHaveAttribute('data-ds-part', 'trigger');
+
+    // Emitted automatically on the root, without an author opting in, and it
+    // must not leak onto the trigger along with the rest props.
+    const root = trigger.closest('[data-ds-component]');
+    expect(root).toHaveAttribute('data-ds-component', 'Select');
     expect(trigger).not.toHaveAttribute('data-ds-component');
 
     // An explicitly passed value wins, still on the root and not the trigger.
-    const overriddenRoot = canvas.getByTestId('ds-override');
-    expect(overriddenRoot).toHaveAttribute('data-ds-component', 'StatusSelect');
-    expect(within(overriddenRoot).getByRole('combobox')).not.toHaveAttribute(
+    const overriddenTrigger = canvas.getByTestId('ds-override');
+    expect(overriddenTrigger.closest('[data-ds-component]')).toHaveAttribute(
       'data-ds-component',
+      'StatusSelect',
     );
+    expect(overriddenTrigger).not.toHaveAttribute('data-ds-component');
 
     // The portaled listbox is `List`, so it never reports as the Select.
     trigger.focus();

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -441,6 +441,11 @@ export const TestIdReachesPortaledListbox: Story = {
     expect(root).toContainElement(trigger);
     expect(trigger).not.toHaveAttribute('data-testid');
 
+    // The trigger keeps a stable query handle through `data-ds-part`, which the
+    // component emits on its own. It marks the trigger only, never the root.
+    expect(trigger).toHaveAttribute('data-ds-part', 'trigger');
+    expect(root).not.toHaveAttribute('data-ds-part');
+
     trigger.focus();
     await userEvent.keyboard('{ArrowDown}');
 
@@ -448,10 +453,13 @@ export const TestIdReachesPortaledListbox: Story = {
 
     // The listbox is portaled out of the root, so only the chain connects them.
     expect(root.contains(listbox)).toBe(false);
-    expect(listbox.closest('[data-ds-chain]')).toHaveAttribute(
-      'data-ds-chain',
-      'filters>status',
-    );
+
+    const chainRoot = listbox.closest('[data-ds-chain]');
+
+    // The chain is built from `data-testid` alone, so the trigger's
+    // `data-ds-part` contributes no node to it.
+    expect(chainRoot).toHaveAttribute('data-ds-chain', 'filters>status');
+    expect(chainRoot?.getAttribute('data-ds-chain')).not.toContain('trigger');
   },
   parameters: { controls: { disable: true } },
 };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -41,6 +41,7 @@ import { splitProps } from '~/utils/splitProps';
 import { Box, type BoxProps } from '../Box/Box';
 import { Chip } from '../Chip/Chip';
 import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
+import { DsChainScope } from '../DsChainScope/DsChainScope';
 import { Icon } from '../Icon/Icon';
 import { List } from '../List/List';
 import { ListItem } from '../List/ListItem';
@@ -239,13 +240,13 @@ export const Select = (props: SelectProps) => {
     ...rest
   } = props;
   const [className, otherProps] = splitProps(rest);
-  // `data-testid` is pulled out and written on the root instead of the trigger.
-  // `Box` opens a chain scope wherever the test id lands, and the trigger is a
-  // sibling of the portal that renders the listbox, so a scope opened there
-  // could never enclose it. The root does enclose the portal's React-tree
-  // position, so the listbox inherits the id. Only the test id moves; every
-  // other rest prop still lands on the trigger, where consumers expect it.
-  const { 'data-testid': testId, ...triggerProps } = otherProps;
+  // Read, do not remove. `data-testid` stays on the combobox trigger, which is
+  // the element a test drives and the element existing selectors already
+  // target. The chain scope it needs to open is a separate concern, handled
+  // below the return: the trigger is a sibling of the portal that renders the
+  // listbox, so a scope opened by the trigger's own `Box` could never enclose
+  // it, but a scope opened above the root does.
+  const testId = otherProps['data-testid'];
 
   const generatedId = useId();
   const triggerId = id ?? `select-${generatedId}`;
@@ -455,12 +456,8 @@ export const Select = (props: SelectProps) => {
     handleValueChange(nextValues.length > 0 ? nextValues : null);
   };
 
-  return (
-    <Box
-      {...dsComponent('Select', dsComponentName)}
-      className={classes.root}
-      data-testid={testId}
-    >
+  const root = (
+    <Box {...dsComponent('Select', dsComponentName)} className={classes.root}>
       {name &&
         selectedValues.map((selectedValue) => (
           <Box
@@ -501,7 +498,7 @@ export const Select = (props: SelectProps) => {
         {...(getReferenceProps({
           onKeyDown: handleTriggerKeyDown,
         }) as Record<string, unknown>)}
-        {...triggerProps}
+        {...otherProps}
       >
         {multiple && selectedOptions.length > 0 ? (
           <Box className={cx(classes.content, classes.chips)}>
@@ -616,5 +613,16 @@ export const Select = (props: SelectProps) => {
         </FloatingPortal>
       )}
     </Box>
+  );
+
+  // The scope is opened above the root rather than by the element carrying the
+  // id, because only the root encloses the portal's position in the React tree.
+  // The trigger's own `Box` opens a second scope with the same id; the repeat
+  // is collapsed in `extendDsChain`, so content inside the trigger resolves the
+  // same chain as content outside it.
+  return typeof testId === 'string' && testId.length > 0 ? (
+    <DsChainScope testId={testId}>{root}</DsChainScope>
+  ) : (
+    root
   );
 };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -34,6 +34,7 @@ import {
   createOverlayMiddleware,
   useOverlayFloating,
 } from '~/system/floating-ui/floating';
+import { dsPart } from '~/utils/dsPart';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
@@ -466,8 +467,15 @@ export const Select = (props: SelectProps) => {
           />
         ))}
 
+      {/*
+        `data-ds-part` gives the trigger a stable query handle now that
+        `data-testid` is written on the root. It is internal instrumentation,
+        not a supported prop, and the chain reads `data-testid` only, so it adds
+        no chain node.
+      */}
       <Box
         as="div"
+        {...dsPart('trigger')}
         id={triggerId}
         ref={floating.refs.setReference}
         className={`${cx(classes.trigger, className)} peer`}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -34,6 +34,7 @@ import {
   createOverlayMiddleware,
   useOverlayFloating,
 } from '~/system/floating-ui/floating';
+import { dsComponent } from '~/utils/dsComponent';
 import { dsPart } from '~/utils/dsPart';
 import { splitProps } from '~/utils/splitProps';
 
@@ -234,6 +235,7 @@ export const Select = (props: SelectProps) => {
     size = 'md',
     density = defaultDensity,
     autoSize = false,
+    'data-ds-component': dsComponentName,
     ...rest
   } = props;
   const [className, otherProps] = splitProps(rest);
@@ -454,7 +456,11 @@ export const Select = (props: SelectProps) => {
   };
 
   return (
-    <Box className={classes.root} data-testid={testId}>
+    <Box
+      {...dsComponent('Select', dsComponentName)}
+      className={classes.root}
+      data-testid={testId}
+    >
       {name &&
         selectedValues.map((selectedValue) => (
           <Box

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -38,6 +38,7 @@ import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box/Box';
 import { Chip } from '../Chip/Chip';
+import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
 import { Icon } from '../Icon/Icon';
 import { List } from '../List/List';
 import { ListItem } from '../List/ListItem';
@@ -526,69 +527,71 @@ export const Select = (props: SelectProps) => {
 
       {isOpen && !disabled && (
         <FloatingPortal>
-          <FloatingFocusManager
-            context={floating.context}
-            modal={false}
-            initialFocus={-1}
-          >
-            {/* validate-ignore: useSemanticElements — custom select popup uses ARIA listbox semantics on a non-native container */}
-            <List
-              ref={floating.refs.setFloating}
-              id={listboxId}
-              role="listbox"
-              aria-labelledby={triggerId}
-              aria-multiselectable={multiple || undefined}
-              density={density}
-              className={menuClasses.wrapper}
-              style={floating.floatingStyles}
-              {...(getFloatingProps() as Record<string, unknown>)}
+          <DsChainPortalRoot>
+            <FloatingFocusManager
+              context={floating.context}
+              modal={false}
+              initialFocus={-1}
             >
-              {options.map((option, index) => {
-                const optionLabel = getOptionText(option);
-                const isSelected = multiple
-                  ? selectedValueSet.has(option.props.value)
-                  : value === option.props.value;
+              {/* validate-ignore: useSemanticElements — custom select popup uses ARIA listbox semantics on a non-native container */}
+              <List
+                ref={floating.refs.setFloating}
+                id={listboxId}
+                role="listbox"
+                aria-labelledby={triggerId}
+                aria-multiselectable={multiple || undefined}
+                density={density}
+                className={menuClasses.wrapper}
+                style={floating.floatingStyles}
+                {...(getFloatingProps() as Record<string, unknown>)}
+              >
+                {options.map((option, index) => {
+                  const optionLabel = getOptionText(option);
+                  const isSelected = multiple
+                    ? selectedValueSet.has(option.props.value)
+                    : value === option.props.value;
 
-                return (
-                  <ListItem
-                    key={option.props.value}
-                    id={`${triggerId}-option-${index}`}
-                    ref={(node: HTMLElement | null) => {
-                      itemRefs.current[index] = node;
-                      labelsRef.current[index] = optionLabel;
-                    }}
-                    disabled={option.props.disabled}
-                    selected={isSelected}
-                    variant={multiple ? 'checkbox' : 'default'}
-                    label={optionLabel}
-                    description={option.props.description}
-                    iconBefore={
-                      !multiple
-                        ? (option.props.iconLeft ?? 'check')
-                        : option.props.iconLeft
-                    }
-                    iconBeforeFill={
-                      !multiple
-                        ? isSelected
-                          ? 'icon'
+                  return (
+                    <ListItem
+                      key={option.props.value}
+                      id={`${triggerId}-option-${index}`}
+                      ref={(node: HTMLElement | null) => {
+                        itemRefs.current[index] = node;
+                        labelsRef.current[index] = optionLabel;
+                      }}
+                      disabled={option.props.disabled}
+                      selected={isSelected}
+                      variant={multiple ? 'checkbox' : 'default'}
+                      label={optionLabel}
+                      description={option.props.description}
+                      iconBefore={
+                        !multiple
+                          ? (option.props.iconLeft ?? 'check')
                           : option.props.iconLeft
-                            ? undefined
-                            : 'transparent'
-                        : undefined
-                    }
-                    iconAfter={option.props.iconRight}
-                    {...(getItemProps({
-                      onClick: () => {
-                        if (!option.props.disabled) {
-                          handleOptionSelect(option.props.value);
-                        }
-                      },
-                    } as HTMLProps<HTMLElement>) as Record<string, unknown>)}
-                  />
-                );
-              })}
-            </List>
-          </FloatingFocusManager>
+                      }
+                      iconBeforeFill={
+                        !multiple
+                          ? isSelected
+                            ? 'icon'
+                            : option.props.iconLeft
+                              ? undefined
+                              : 'transparent'
+                          : undefined
+                      }
+                      iconAfter={option.props.iconRight}
+                      {...(getItemProps({
+                        onClick: () => {
+                          if (!option.props.disabled) {
+                            handleOptionSelect(option.props.value);
+                          }
+                        },
+                      } as HTMLProps<HTMLElement>) as Record<string, unknown>)}
+                    />
+                  );
+                })}
+              </List>
+            </FloatingFocusManager>
+          </DsChainPortalRoot>
         </FloatingPortal>
       )}
     </Box>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -236,6 +236,13 @@ export const Select = (props: SelectProps) => {
     ...rest
   } = props;
   const [className, otherProps] = splitProps(rest);
+  // `data-testid` is pulled out and written on the root instead of the trigger.
+  // `Box` opens a chain scope wherever the test id lands, and the trigger is a
+  // sibling of the portal that renders the listbox, so a scope opened there
+  // could never enclose it. The root does enclose the portal's React-tree
+  // position, so the listbox inherits the id. Only the test id moves; every
+  // other rest prop still lands on the trigger, where consumers expect it.
+  const { 'data-testid': testId, ...triggerProps } = otherProps;
 
   const generatedId = useId();
   const triggerId = id ?? `select-${generatedId}`;
@@ -446,7 +453,7 @@ export const Select = (props: SelectProps) => {
   };
 
   return (
-    <Box className={classes.root}>
+    <Box className={classes.root} data-testid={testId}>
       {name &&
         selectedValues.map((selectedValue) => (
           <Box
@@ -480,7 +487,7 @@ export const Select = (props: SelectProps) => {
         {...(getReferenceProps({
           onKeyDown: handleTriggerKeyDown,
         }) as Record<string, unknown>)}
-        {...otherProps}
+        {...triggerProps}
       >
         {multiple && selectedOptions.length > 0 ? (
           <Box className={cx(classes.content, classes.chips)}>

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -583,6 +583,37 @@ export const DsComponentAttribute: Story = {
   parameters: { controls: { disable: true } },
 };
 
+export const ConsumerClassName: Story = {
+  name: 'Test: consumer className',
+  render: () => (
+    <VStack alignItems="start" gap="8">
+      <TextInput
+        name="class-name"
+        aria-label="Class name input"
+        className="consumer-class"
+        iconBefore="search"
+      />
+    </VStack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Class name input');
+    const container = input.parentElement;
+
+    if (!(container instanceof HTMLElement)) {
+      throw new Error('TextInput should render a container around the input.');
+    }
+
+    // A consumer className styles the component root once.
+    expect(container).toHaveClass('consumer-class');
+
+    // The native input keeps only its recipe class, so a single className
+    // prop cannot style two elements at once.
+    expect(input).not.toHaveClass('consumer-class');
+  },
+  parameters: { controls: { disable: true } },
+};
+
 // ============================================================================
 // Interactive Playground
 // ============================================================================

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -188,7 +188,10 @@ export const TextInput = (props: TextInputProps) => {
         data-valid={valid || undefined}
         data-invalid={invalid || undefined}
         aria-invalid={invalid || undefined}
-        className={cx(classes.input, className)}
+        // The consumer className and Panda style props are applied to the
+        // container root above; applying them here too would style two
+        // elements from a single prop.
+        className={classes.input}
         autoComplete={autoComplete}
         {...otherProps}
       />

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -25,6 +25,7 @@ import {
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
+import { DsChainPortalRoot } from '../DsChainScope/DsChainPortalRoot';
 import { Text } from '../Text';
 
 /** Props for {@link Tooltip}, nonessential contextual text shown on hover or focus. */
@@ -133,23 +134,25 @@ export const Tooltip = (props: TooltipProps) => {
 
       {isOpen && (
         <FloatingPortal>
-          <Box
-            ref={refs.setFloating}
-            style={floatingStyles}
-            className={cx(classes.tooltipContent, className)}
-            {...(getFloatingProps() as Record<string, unknown>)}
-            {...otherProps}
-          >
-            {title && <Text className={classes.title}>{title}</Text>}
-            {text && <Text className={classes.text}>{text}</Text>}
-            {caret && (
-              <FloatingArrow
-                ref={arrowRef}
-                context={context}
-                fill={token.var('colors.bg.neutral.inverse')}
-              />
-            )}
-          </Box>
+          <DsChainPortalRoot>
+            <Box
+              ref={refs.setFloating}
+              style={floatingStyles}
+              className={cx(classes.tooltipContent, className)}
+              {...(getFloatingProps() as Record<string, unknown>)}
+              {...otherProps}
+            >
+              {title && <Text className={classes.title}>{title}</Text>}
+              {text && <Text className={classes.text}>{text}</Text>}
+              {caret && (
+                <FloatingArrow
+                  ref={arrowRef}
+                  context={context}
+                  fill={token.var('colors.bg.neutral.inverse')}
+                />
+              )}
+            </Box>
+          </DsChainPortalRoot>
         </FloatingPortal>
       )}
     </>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -22,6 +22,7 @@ import {
   createOverlayMiddleware,
   useOverlayFloating,
 } from '~/system/floating-ui/floating';
+import { dsComponent } from '~/utils/dsComponent';
 import { splitProps } from '~/utils/splitProps';
 
 import { Box, type BoxProps } from '../Box';
@@ -136,6 +137,7 @@ export const Tooltip = (props: TooltipProps) => {
         <FloatingPortal>
           <DsChainPortalRoot>
             <Box
+              {...dsComponent('Tooltip')}
               ref={refs.setFloating}
               style={floatingStyles}
               className={cx(classes.tooltipContent, className)}

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,10 @@ export {
   type TimeFormat,
 } from './components/DateTime';
 export { Divider, type DividerProps } from './components/Divider';
+export {
+  DsChainScope,
+  type DsChainScopeProps,
+} from './components/DsChainScope';
 export { FormField, type FormFieldProps } from './components/FormField';
 export { Heading, type HeadingProps } from './components/Heading';
 export {

--- a/src/utils/dsChain.ts
+++ b/src/utils/dsChain.ts
@@ -11,6 +11,14 @@ export const DS_CHAIN_ATTRIBUTE = 'data-ds-chain';
 export const DS_CHAIN_SEPARATOR = '>';
 
 /**
+ * Attribute marking the wrapper a portal's contents render into. Written
+ * unconditionally, including when the resolved chain is empty, so a consumer
+ * walking up the DOM can tell a portal boundary from an ordinary element and
+ * stop there instead of continuing into `document.body`.
+ */
+export const DS_PORTAL_ROOT_ATTRIBUTE = 'data-ds-portal-root';
+
+/**
  * Maximum number of chain nodes retained. The nearest nodes are kept because
  * the leaf end of the chain is what identifies an interaction; page-level
  * object identity is carried separately rather than through this chain.
@@ -40,11 +48,24 @@ export const useDsChain = (): readonly string[] => useContext(DsChainContext);
 /**
  * Appends a `data-testid` value to a chain, keeping the nearest
  * `DS_CHAIN_MAX_DEPTH` nodes.
+ *
+ * A value equal to the innermost node is dropped rather than repeated. Two
+ * supported arrangements produce that case: a component that opens a scope
+ * above its root and also writes the same id on an inner element, and a
+ * consumer that wraps a design-system component in `DsChainScope` using the
+ * `data-testid` that component already emits. Neither is an error, and a
+ * repeated node carries no information while it consumes one of five slots.
+ *
+ * Only the innermost node is compared. A legitimately recurring id further out
+ * — a nested grid inside a grid — still contributes, because the repeat there
+ * describes real structure.
  */
 export const extendDsChain = (
   chain: readonly string[],
   testId: string,
 ): readonly string[] => {
+  if (chain[chain.length - 1] === testId) return chain;
+
   const next = [...chain, testId];
 
   return next.length > DS_CHAIN_MAX_DEPTH

--- a/src/utils/dsChain.ts
+++ b/src/utils/dsChain.ts
@@ -1,0 +1,62 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Attribute name that carries a resolved interaction chain on a portal root.
+ * Always lowercase and hyphenated; HTML lowercases attribute names, so a
+ * camelCase spelling would silently produce a different attribute.
+ */
+export const DS_CHAIN_ATTRIBUTE = 'data-ds-chain';
+
+/** Separator written between chain nodes in the serialized attribute value. */
+export const DS_CHAIN_SEPARATOR = '>';
+
+/**
+ * Maximum number of chain nodes retained. The nearest nodes are kept because
+ * the leaf end of the chain is what identifies an interaction; page-level
+ * object identity is carried separately rather than through this chain.
+ */
+export const DS_CHAIN_MAX_DEPTH = 5;
+
+// Module-level constant so every reader outside a scope shares one identity.
+// A fresh `[]` default would hand consumers a new value on each render and
+// defeat the memoization in the provider.
+const EMPTY_CHAIN: readonly string[] = Object.freeze([]);
+
+/**
+ * Carries the `data-testid` values of the enclosing tagged elements, nearest
+ * last. React context walks the React tree rather than the DOM, so portaled
+ * content still resolves the chain of the subtree that rendered it.
+ */
+export const DsChainContext = createContext<readonly string[]>(EMPTY_CHAIN);
+
+/**
+ * Returns the interaction chain for the current position in the React tree.
+ *
+ * Returns a shared empty array outside any scope, so the result is safe to read
+ * unconditionally.
+ */
+export const useDsChain = (): readonly string[] => useContext(DsChainContext);
+
+/**
+ * Appends a `data-testid` value to a chain, keeping the nearest
+ * `DS_CHAIN_MAX_DEPTH` nodes.
+ */
+export const extendDsChain = (
+  chain: readonly string[],
+  testId: string,
+): readonly string[] => {
+  const next = [...chain, testId];
+
+  return next.length > DS_CHAIN_MAX_DEPTH
+    ? next.slice(-DS_CHAIN_MAX_DEPTH)
+    : next;
+};
+
+/**
+ * Serializes a chain for the `data-ds-chain` attribute.
+ *
+ * Returns `undefined` for an empty chain so React omits the attribute instead
+ * of emitting an empty string that consumers would have to special-case.
+ */
+export const dsChainValue = (chain: readonly string[]): string | undefined =>
+  chain.length > 0 ? chain.join(DS_CHAIN_SEPARATOR) : undefined;

--- a/src/utils/dsPart.ts
+++ b/src/utils/dsPart.ts
@@ -15,12 +15,15 @@ export type DsPartAttribute = {
  *
  * Internal instrumentation with the same status as `data-ds-component`: emitted
  * automatically, not a supported public API, and not part of any prop type.
- * It exists because some components move `data-testid` off the element a test
- * actually drives. `Box` opens an interaction-chain scope wherever a
- * `data-testid` lands, so a component whose popup is portaled must write the id
- * on a root that encloses the portal's React-tree position. That leaves the
- * trigger with no stable query handle, and a second `data-testid` there would
- * push the same id into the chain twice.
+ * **It is not a test handle** — tests query by role, or by the `data-testid` a
+ * consumer supplied. Do not document it, type it, or reference it from a test
+ * outside this repository.
+ *
+ * It exists for the collector, which needs to tell apart the interactive parts
+ * of one component: a click on a `Select`'s trigger is a different event from a
+ * click on a chip's remove control inside it, and both report the same
+ * `data-ds-component` and the same chain. The part name is what separates them,
+ * and it is the DS's to assign because only the DS knows its own anatomy.
  *
  * Spread the result before the component's rest props so a consumer-supplied
  * value in rest props still wins, matching `dsComponent`.

--- a/src/utils/dsPart.ts
+++ b/src/utils/dsPart.ts
@@ -1,0 +1,38 @@
+/**
+ * Attribute name that names an interactive part inside a design-system
+ * component. Always lowercase and hyphenated; HTML lowercases attribute names,
+ * so a camelCase spelling would silently produce a different attribute.
+ */
+export const DS_PART_ATTRIBUTE = 'data-ds-part';
+
+/** Attribute record applied to a named part of a design-system component. */
+export type DsPartAttribute = {
+  'data-ds-part': string;
+};
+
+/**
+ * Returns the `data-ds-part` attribute for a named part of a component.
+ *
+ * Internal instrumentation with the same status as `data-ds-component`: emitted
+ * automatically, not a supported public API, and not part of any prop type.
+ * It exists because some components move `data-testid` off the element a test
+ * actually drives. `Box` opens an interaction-chain scope wherever a
+ * `data-testid` lands, so a component whose popup is portaled must write the id
+ * on a root that encloses the portal's React-tree position. That leaves the
+ * trigger with no stable query handle, and a second `data-testid` there would
+ * push the same id into the chain twice.
+ *
+ * Spread the result before the component's rest props so a consumer-supplied
+ * value in rest props still wins, matching `dsComponent`.
+ *
+ * The chain mechanism reads `data-testid` only (see `Box` and
+ * `~/utils/dsChain`), so this attribute never contributes a chain node.
+ *
+ * @example
+ * ```tsx
+ * <Box role="combobox" {...dsPart('trigger')} {...triggerProps} />
+ * ```
+ */
+export const dsPart = (part: string): DsPartAttribute => ({
+  [DS_PART_ATTRIBUTE]: part,
+});


### PR DESCRIPTION
## Update — review revisions (2026-08-19)

Revised after a review pass against `INSTRUMENTATION-PLAN.md`. **Two changes reverse
behavior described earlier in this PR**, so the description above is out of date where
it disagrees with this section.

### `data-testid` stays where the consumer put it

An earlier revision moved `Select`'s `data-testid` from the combobox trigger to the
component root, so the chain scope it opens would enclose the portaled listbox. That
was a consumer break — any existing `getByTestId` against a `Select` would have
resolved to a wrapper `<div>` instead of the combobox, silently breaking `.fill()`,
`.press()` and role assertions.

**Reverted.** The test ID stays on the trigger. The scope is now opened *above* the
root instead, which decouples "which element wears the ID" from "which element opens
the scope" — only the root encloses the portal's position in the React tree, but it
doesn't need to carry the attribute to do that.

Consequence: the trigger's own `Box` opens a second scope with the same ID, so
`extendDsChain` now collapses a repeated innermost node. That also covers a consumer
wrapping a tagged DS component in `DsChainScope`. Non-adjacent repeats — a grid nested
in a grid — still contribute, because there the repeat is real structure.

### Portal roots are marked unconditionally

`data-ds-chain` is omitted when the chain is empty, which left the portal wrapper as an
anonymous `<div>`. A consumer walking up the DOM would pass straight through it into
`document.body` and build a chain from whatever it found — the silent-wrong-chain
failure this PR exists to prevent, reintroduced for any subtree nobody has tagged yet
(today: almost all of them).

Portal roots now always carry `data-ds-portal-root`. **Consumer rule:** when a DOM
walk-up reaches `data-ds-portal-root`, stop. Use `data-ds-chain` if present; otherwise
record the chain as unresolved. Never continue past a portal root.

### `data-ds-part` is not a test handle

It was introduced as the replacement query handle for the trigger. With the test ID
back on the trigger it no longer serves that purpose, and it is **not** a supported
public API — not typed, not documented, not for use in tests. Docstring rewritten to
justify it on the consumer side instead: it distinguishes interactive parts within one
component, which `data-ds-component` and the chain cannot.

### Public API surface — unchanged

`DsChainScope` remains the only new export. `data-ds-component`, `data-ds-part`,
`data-ds-chain` and `data-ds-portal-root` are all emitted automatically and are
internal.

### Verification

| Check | Result |
|---|---|
| `npm run lint` | pass (exit 0) |
| `npm run typecheck` | pass (exit 0) |
| `npm run build` | pass — 341 modules, d.ts rollup clean, ~34s |
| Storybook play stories | **10/10 pass, executed** — 7 `DsChainScope`, 3 `Select` |

The play stories were run rather than assumed. Nothing in CI executes them, so they had
never been exercised on this branch before now. Two new ones cover the revisions:
repeated-node collapse, and a findable portal boundary with an empty chain.

No release label applied — `major`/`minor`/`patch`/`release` are manual in this repo
and one of them publishes a prerelease on merge.

### Follow-up, not blocking this PR

Confirmed separately in the app repo: the legacy layout wrapper that Track B would tag
with `data-track-object` sits one level *inside* `<body>`, and `FloatingPortal` appends
to `<body>` — so portaled content lands as its sibling and can't reach it. The chain
carries `data-testid` only, so it doesn't restore that either. Tracked in
`INSTRUMENTATION-PLAN.md` v0.3; the likely fix is an app-side or `FloatingPortal`
`root` change, not a change here.

---

**Stacked on #183 — review that one first.** Base is `feat/ds-component-attribute`; it will retarget to `main` automatically once #183 lands. The diff shown here is only the 5 commits on top.

Builds the second half of the instrumentation layer: identifying *parts within* a component, and resolving interaction chains that cross a portal boundary.

## What's here

**New utils**
- `src/utils/dsPart.ts` — emits `data-ds-part` for sub-elements (triggers, panels, items).
- `src/utils/dsChain.ts` — resolves the logical parent chain across portals, so a menu item rendered in a portal still reports its owning component.

**Component changes**
- `Menu`, `SubMenu`, `Modal`, `Select`, `Tooltip` — portal roots now carry `data-ds-component`, and triggers carry `data-ds-part`.
- `Select` — test id now routes to the root element rather than an inner node.
- `Pre` and `TextInput` — stop double-spreading props. This was a real bug independent of instrumentation: props were applied twice, so the later spread silently won.

**Coverage**
- Story additions for `Select` and `TextInput`.

## Why the chain util exists

Radix-style portals render outside the component's DOM subtree, so an ancestor walk from a portaled element never reaches the component root. `dsChain` carries the association explicitly instead of inferring it from position.

## Notes

- Additive; no public API removed. `src/index.ts` exports the three new utils.
- No release label applied — per the release docs, a `minor`/`patch` label publishes a prerelease, which should be a deliberate call at merge time.

## Verification

Run locally on the branch tip (`c0c8f525`):

| Check | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run build` | ✅ pass (exit 0, 341 modules, d.ts rollup clean) |
| `npm run lint` | ✅ pass (exit 0) |
| Storybook play stories | ⚠️ not run |

### ⚠️ Note on the first `deploy-pr-preview` failure

The initial run of `deploy-pr-preview` on this PR failed, and **it was not a defect in this branch** — the build succeeded and only the final `git push` was rejected:

```
! [rejected]  gh-pages -> gh-pages (fetch first)
```

This PR and #183 were opened seconds apart, so both preview deploys raced to push to the shared `gh-pages` branch. #183 won; this one was rejected as non-fast-forward. Resolved by re-running the job.

**This exposes a real bug in `.github/workflows/deploy_gh_pages.yml`** (separate from this PR, not fixed here):

```yaml
concurrency:
  group: pages-deploy-${{ github.event.pull_request.number || 'main' }}
  cancel-in-progress: true
```

The guard is keyed **per-PR**, but the contended resource is the single shared `gh-pages` branch. Two different PRs therefore land in two different groups and deploy concurrently — precisely what the comment above it says the guard exists to prevent. Any two PRs opened close together will hit this. A constant group key (and `cancel-in-progress: false`, since cancelling a mid-push deploy leaves previews unpublished) would fix it.

## Open questions for review

- Should `dsPart` values be free-form strings or a constrained union? Currently free-form.
- The three utils are exported publicly. If they're meant to be internal-only, that should change before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
