### PR TITLE
ci(patch): serialize all gh-pages pushes behind one global lock

### DIFF
--- a/.github/workflows/cleanup_pr_preview.yml
+++ b/.github/workflows/cleanup_pr_preview.yml
@@ -10,6 +10,12 @@ permissions:
 jobs:
   cleanup-pr-preview:
     runs-on: ubuntu-latest
+    # Shares the global gh-pages lock with deploy_gh_pages.yml. Closing a PR
+    # while another PR's preview is deploying pushes to the same branch, so
+    # this job has to queue behind it like any other writer.
+    concurrency:
+      group: gh-pages-push
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cleanup_pr_preview.yml
+++ b/.github/workflows/cleanup_pr_preview.yml
@@ -16,6 +16,7 @@ jobs:
     concurrency:
       group: gh-pages-push
       cancel-in-progress: false
+      queue: max
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -60,6 +60,7 @@ jobs:
     concurrency:
       group: gh-pages-push
       cancel-in-progress: false
+      queue: max
 
     steps:
       - uses: actions/checkout@v4
@@ -114,6 +115,7 @@ jobs:
     concurrency:
       group: gh-pages-push
       cancel-in-progress: false
+      queue: max
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -22,7 +22,9 @@ permissions:
   contents: write
   pull-requests: write
 
-# Prevent concurrent deployments to avoid git conflicts
+# Supersede an in-flight run when the same PR (or main) gets another push.
+# Keyed per-PR on purpose: this is about not wasting runners on stale commits.
+# It does NOT protect the gh-pages branch — see the job-level guard below.
 concurrency:
   group: pages-deploy-${{ github.event.pull_request.number || 'main' }}
   cancel-in-progress: true
@@ -51,6 +53,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: validate
     runs-on: ubuntu-latest
+    # Every job that pushes to gh-pages shares ONE global lock. The branch is a
+    # single mutable resource, so two jobs pushing at once produce a
+    # non-fast-forward rejection. Never cancel-in-progress here: a cancelled
+    # deploy leaves the preview unpublished with a green-looking run.
+    concurrency:
+      group: gh-pages-push
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
@@ -101,6 +110,10 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
+    # Shares the global gh-pages lock — see deploy-main above.
+    concurrency:
+      group: gh-pages-push
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes a concurrency guard that has never actually guarded the thing it names.

## The bug

`deploy_gh_pages.yml` carried this, with a comment stating the correct intent:

```yaml
# Prevent concurrent deployments to avoid git conflicts
concurrency:
  group: pages-deploy-${{ github.event.pull_request.number || 'main' }}
  cancel-in-progress: true
```

The group key is **per-PR**, but the resource it protects — `gh-pages` — is a single shared mutable branch. Two different PRs therefore land in two different concurrency groups and deploy at the same time. The guard only ever protected a PR from itself.

The second pusher loses:

```
! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref.
```

**Any two PRs opened or pushed close together hit this.** The build succeeds in full and only the final push fails, so it presents as a flaky deploy rather than a config error — which is probably why it's survived.

Observed on #184, which raced #183 earlier today. Re-running the job cleared it, but re-running is the workaround, not the fix.

## Third racer

`cleanup_pr_preview.yml` also pushes to `gh-pages` and had **no concurrency guard at all**. Closing a PR while another PR's preview is deploying is the same collision from a different direction.

## The fix

A job-level group, `gh-pages-push`, shared by all three jobs that write to the branch — `deploy-main`, `deploy-pr-preview`, `cleanup-pr-preview`. Concurrency groups are repo-scoped, so one key serializes across both workflow files.

`cancel-in-progress: false` on all three, deliberately: cancelling a job mid-push leaves the preview unpublished while the run still reports green. Queuing is correct here, cancelling is not.

**The existing per-PR top-level guard is kept unchanged.** It does a different and still-useful job — superseding stale runs when a PR is pushed twice — and it's now commented to say so, since the old comment was the thing that made this look already-solved.

## Trade-off

Deploys now serialize globally instead of running in parallel. With `deploy-pr-preview` at ~2m30s–3m, several PRs updating at once will queue. That's the intended cost: a queued deploy is slower, a raced deploy is broken.

## Verification

- Both workflow files parse as valid YAML; job-level `concurrency` blocks confirmed present on all three jobs and absent from `validate` (which touches nothing and should stay parallel).
- Diff is 2 files, modifications only, no deletions.
- The real proof is behavioral and can't be run pre-merge: it needs two PRs deploying simultaneously on `main`. Worth watching the next time two PRs land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-next.0`

<details>
  <summary>Changelog</summary>

  #### ⚠️ Pushed to `main`
  
  - fix: release ([@Etwigg](https://github.com/Etwigg))
  
  #### 📦 Misc Changes
  
  - refactor(major): rebuild date and time picker APIs [#174](https://github.com/Cetec-ERP/Cetec-Design-System/pull/174) ([@shaunrfox](https://github.com/shaunrfox))
  - refactor: pass href prop to render listitem as anchor [#165](https://github.com/Cetec-ERP/Cetec-Design-System/pull/165) ([@atkinsdavid](https://github.com/atkinsdavid))
  - refactor(minor): remove compound variants and support responsive sizing [#154](https://github.com/Cetec-ERP/Cetec-Design-System/pull/154) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### 🚀 Features
  
  - feat(minor): release add rowId prop to ListItem [#188](https://github.com/Cetec-ERP/Cetec-Design-System/pull/188) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - feat(minor): emit data-ds-part and resolve interaction chains across portals [#184](https://github.com/Cetec-ERP/Cetec-Design-System/pull/184) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): emit data-ds-component on component roots [#183](https://github.com/Cetec-ERP/Cetec-Design-System/pull/183) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - feat(minor): add autocomplete component [#175](https://github.com/Cetec-ERP/Cetec-Design-System/pull/175) ([@shaunrfox](https://github.com/shaunrfox))
  - feat: shadow refactor to add dropShadow property and tokens [#170](https://github.com/Cetec-ERP/Cetec-Design-System/pull/170) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): add uncontrolled support and static-safe visuals for form components [#169](https://github.com/Cetec-ERP/Cetec-Design-System/pull/169) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): select-component [#158](https://github.com/Cetec-ERP/Cetec-Design-System/pull/158) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - feat: added skeleton component and stories [#166](https://github.com/Cetec-ERP/Cetec-Design-System/pull/166) ([@shaunrfox](https://github.com/shaunrfox))
  - feat: keyboard-component [#159](https://github.com/Cetec-ERP/Cetec-Design-System/pull/159) ([@shaunrfox](https://github.com/shaunrfox))
  - feat(minor): add keyboard UI for Menu components [#153](https://github.com/Cetec-ERP/Cetec-Design-System/pull/153) ([@atkinsdavid](https://github.com/atkinsdavid))
  
  #### 🐛 Bug Fixes
  
  - fix(patch): improve autocomplete selection chips [#187](https://github.com/Cetec-ERP/Cetec-Design-System/pull/187) ([@shaunrfox](https://github.com/shaunrfox))
  - fix: ai review fixes [#177](https://github.com/Cetec-ERP/Cetec-Design-System/pull/177) ([@Etwigg](https://github.com/Etwigg))
  - fix(patch): issue with state for MenuItem toggles [#173](https://github.com/Cetec-ERP/Cetec-Design-System/pull/173) ([@atkinsdavid](https://github.com/atkinsdavid))
  - fix: shared field and slot context layers + arbitrary slot handling [#160](https://github.com/Cetec-ERP/Cetec-Design-System/pull/160) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - fix: try to fix versioning again [#164](https://github.com/Cetec-ERP/Cetec-Design-System/pull/164) ([@Etwigg](https://github.com/Etwigg))
  - fix(patch): block !important in validation checks [#149](https://github.com/Cetec-ERP/Cetec-Design-System/pull/149) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  
  #### 📝 Documentation
  
  - docs(minor): standardize public API documentation [#180](https://github.com/Cetec-ERP/Cetec-Design-System/pull/180) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### 🎨 Styles
  
  - style: fixed conditional styling scope to prevent affects from ancestor data attributes [#172](https://github.com/Cetec-ERP/Cetec-Design-System/pull/172) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### 🏎 Performance
  
  - perf(config): optimize Playroom CSS generation [#182](https://github.com/Cetec-ERP/Cetec-Design-System/pull/182) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### 🤖 CI
  
  - ci(patch): serialize all gh-pages pushes behind one global lock [#186](https://github.com/Cetec-ERP/Cetec-Design-System/pull/186) ([@shaunrfox](https://github.com/shaunrfox))
  - ci: fix CI release version resolution [#176](https://github.com/Cetec-ERP/Cetec-Design-System/pull/176) ([@Etwigg](https://github.com/Etwigg))
  - ci: added manual release workflow [#171](https://github.com/Cetec-ERP/Cetec-Design-System/pull/171) ([@shaunrfox](https://github.com/shaunrfox))
  - ci: fix prerelease in ci [#168](https://github.com/Cetec-ERP/Cetec-Design-System/pull/168) ([@Etwigg](https://github.com/Etwigg))
  - ci: better version resolution [#161](https://github.com/Cetec-ERP/Cetec-Design-System/pull/161) ([@Etwigg](https://github.com/Etwigg))
  
  #### 🏠 Chores
  
  - chore(patch): added semantic fontSizes [#167](https://github.com/Cetec-ERP/Cetec-Design-System/pull/167) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - chore(major): trigger prerelease for #154 [#157](https://github.com/Cetec-ERP/Cetec-Design-System/pull/157) ([@shaunrfox](https://github.com/shaunrfox) [@Etwigg](https://github.com/Etwigg))
  - chore(minor): trigger prerelease for #154 [#156](https://github.com/Cetec-ERP/Cetec-Design-System/pull/156) ([@shaunrfox](https://github.com/shaunrfox))
  
  #### Authors: 3
  
  - David ([@atkinsdavid](https://github.com/atkinsdavid))
  - Ethan W. ([@Etwigg](https://github.com/Etwigg))
  - Shaun Fox ([@shaunrfox](https://github.com/shaunrfox))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
