### PR TITLE
fix(patch): improve autocomplete selection chips

### DIFF
--- a/.playroom/snippets.ts
+++ b/.playroom/snippets.ts
@@ -51,6 +51,64 @@ const snippets = [
 </VStack>`,
   },
   {
+    group: 'Forms',
+    name: 'Autocomplete (Single Select)',
+    code: `<Box maxWidth="sm">
+  <FormField label="Primary technology" labelFor="primary-technology">
+    <Autocomplete
+      id="primary-technology"
+      name="primaryTechnology"
+      defaultValue="react"
+      placeholder="Choose a technology…"
+    >
+      <Option value="react" label="React" description="UI library" />
+      <Option
+        value="typescript"
+        label="TypeScript"
+        description="Type safety"
+      />
+      <Option
+        value="storybook"
+        label="Storybook"
+        description="Component workshop"
+      />
+    </Autocomplete>
+  </FormField>
+</Box>`,
+  },
+  {
+    group: 'Forms',
+    name: 'Autocomplete (Multi Select)',
+    code: `<Box maxWidth="sm">
+  <FormField label="Project stack" labelFor="project-stack">
+    <Autocomplete
+      id="project-stack"
+      name="projectStack"
+      multiple
+      defaultValue={['react', 'typescript']}
+      placeholder="Add technology…"
+    >
+      <Option value="react" label="React" description="UI library" />
+      <Option
+        value="typescript"
+        label="TypeScript"
+        description="Type safety"
+      />
+      <Option
+        value="storybook"
+        label="Storybook"
+        description="Component workshop"
+      />
+      <Option
+        value="panda"
+        label="Panda CSS"
+        description="Build-time styling"
+      />
+    </Autocomplete>
+  </FormField>
+</Box>`,
+  },
+  {
     group: 'Navigation',
     name: 'Breadcrumbs',
     code: `<VStack gap="8" alignItems="flex-start" maxWidth="lg">

--- a/docs/plans/autocomplete-improvement-plan.md
+++ b/docs/plans/autocomplete-improvement-plan.md
@@ -102,21 +102,18 @@ implementation should be recorded in the component documentation and PR.
 
 - `value` represents the selected option; `inputValue` represents editable
   text.
-- Selecting an option commits its display label to the input.
-- Refocusing a selected value selects its text so typing replaces it rather
-  than appending to it.
+- Selecting an option renders its display label in a dismissible chip and
+  clears the query.
+- Typing while a value is selected clears the existing selection and starts a
+  new query.
 - Selecting the currently selected option is a no-op.
-- The control has no clear trigger. Consumers clear controlled state directly,
-  while multiple values can also be removed through their token controls.
-- Editing the displayed text does not silently mutate the selected option. The
-  selected option is cleared when the query diverges according to the final
-  state rules implemented by the hook.
+- The chip dismissal control clears the selected value.
 
 ### Multiple selection
 
-- Selected values render as tokens followed by the native input within the
+- Selected values render as chips followed by the native input within the
   same wrapping value container.
-- Tokens keep their intrinsic width and wrap as needed.
+- Chips keep their intrinsic width and wrap as needed.
 - The input consumes remaining space while retaining a useful minimum editable
   width.
 - Selecting an option clears the query and keeps focus in the input.
@@ -159,7 +156,7 @@ implementation should be recorded in the component documentation and PR.
 
 - Custom values are opt-in through `allowCustomValue`.
 - A non-empty query that does not exactly match an existing selectable option
-  produces a visible `Create “query”` option.
+  produces a visible `Add “query”` option at the top of the listbox.
 - The create option participates in the same keyboard and pointer navigation
   as ordinary options.
 - Enter never creates a value merely because no ordinary option is active.
@@ -697,7 +694,7 @@ the consumer.
   option.
 - Pressing Enter immediately selects the active first option.
 - The control renders no dropdown caret or clear trigger.
-- Custom values appear as an explicit `Create` option.
+- Custom values appear as an explicit `Add` option at the top of the listbox.
 - `limitTags` is numeric and collapses values only while unfocused.
 - Disabled state blocks every mutating interaction.
 - Empty, loading, and loading-more states are visible and accessible.

--- a/public/playroom-static.css
+++ b/public/playroom-static.css
@@ -3250,6 +3250,13 @@
       max-width: var(--cetec-sizes-full);
     }
 
+    .cetec-autocomplete__token[data-new='true'] {
+      background: var(--cetec-colors-transparent);
+      outline-width: var(--cetec-border-widths-1);
+      outline-style: dashed;
+      outline-color: var(--cetec-colors-border-warning);
+    }
+
     .cetec-autocomplete__overflowIndicator {
       background: var(--cetec-colors-bg-neutral);
       padding-inline: var(--cetec-spacing-6);
@@ -3793,6 +3800,7 @@
       position: relative;
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       flex-shrink: 0;
       outline-width: var(--cetec-border-widths-2);
       outline-style: solid;

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -143,12 +143,20 @@ export const Selected: Story = {
     </Box>
   ),
   play: async ({ canvasElement }) => {
-    const input = within(canvasElement).getByRole('combobox', {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', {
       name: 'Technology',
     });
+    await expect(input).toHaveValue('');
+    await expect(
+      canvas.getByRole('button', { name: 'Remove React' }),
+    ).toBeInTheDocument();
     await userEvent.click(input);
     await userEvent.keyboard('P');
     await expect(input).toHaveValue('P');
+    await expect(
+      canvas.queryByRole('button', { name: 'Remove React' }),
+    ).not.toBeInTheDocument();
   },
 };
 
@@ -337,15 +345,24 @@ export const AllowCustomValue: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole('combobox');
-    await userEvent.type(input, 'Svelte');
+    await userEvent.type(input, 'Script');
     const body = within(document.body);
+    const options = body.getAllByRole('option');
+    await expect(options[0]).toHaveAccessibleName(/add “script”/i);
+    await expect(options[1]).toHaveAccessibleName(/typescript type safety/i);
+    await userEvent.keyboard('{Enter}');
+    const removeScript = canvas.getByRole('button', {
+      name: 'Remove Script',
+    });
+    await expect(removeScript).toBeInTheDocument();
+    await expect(removeScript.parentElement).toHaveAttribute(
+      'data-new',
+      'true',
+    );
+    await userEvent.type(input, 'React');
     await expect(
-      body.getByRole('option', { name: /create “svelte”/i }),
-    ).toBeInTheDocument();
-    await userEvent.keyboard('{ArrowDown}{Enter}');
-    await expect(
-      canvas.getByRole('button', { name: 'Remove Svelte' }),
-    ).toBeInTheDocument();
+      body.queryByRole('option', { name: /add “react”/i }),
+    ).not.toBeInTheDocument();
   },
   parameters: { controls: { disable: true } },
 };
@@ -538,7 +555,10 @@ export const KeyboardSelection: Story = {
     await expect(input).toHaveAttribute('aria-expanded', 'true');
     await expect(input).toHaveAttribute('aria-activedescendant');
     await userEvent.keyboard('{Enter}');
-    await expect(input).toHaveValue('React');
+    await expect(input).toHaveValue('');
+    await expect(
+      canvas.getByRole('button', { name: 'Remove React' }),
+    ).toBeInTheDocument();
   },
   parameters: { controls: { disable: true } },
 };

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -75,8 +75,8 @@ type AutocompleteBaseProps = Omit<
     /** Creates the visible label for a custom-value option. */
     getCreateOptionLabel?: (inputValue: string) => string;
     /**
-     * Maximum selected tokens shown while an unfocused multiple Autocomplete
-     * is collapsed. Negative values and `undefined` show every token.
+     * Maximum selected chips shown while an unfocused multiple Autocomplete
+     * is collapsed. Negative values and `undefined` show every chip.
      */
     limitTags?: number;
     /**
@@ -171,7 +171,7 @@ export type SingleAutocompleteProps = AutocompleteBaseProps & {
 
 /** Props for a multiple-selection {@link Autocomplete}. */
 export type MultipleAutocompleteProps = AutocompleteBaseProps & {
-  /** Enables multiple selection and renders selected values as tokens. */
+  /** Enables multiple selection. Selected values render as chips. */
   multiple: true;
   /** Controlled selected values. Pair with `onValueChange`. */
   value?: AutocompleteValue<true>;
@@ -208,6 +208,8 @@ export type AutocompleteProps<Multiple extends boolean = boolean> =
  * with `defaultValue`. The input uses combobox semantics; arrow keys navigate,
  * Enter selects, and Escape closes the listbox. Supply `aria-label` or
  * `aria-labelledby` when no external label is associated with the input.
+ * Selected values render as dismissible chips in both single- and
+ * multiple-selection modes.
  *
  * @example
  * ```tsx
@@ -234,7 +236,6 @@ export const Autocomplete = (props: AutocompleteProps) => {
     currentValue,
     density,
     disabled,
-    displayedInputValue,
     error,
     floating,
     getFloatingProps,
@@ -246,7 +247,6 @@ export const Autocomplete = (props: AutocompleteProps) => {
     handleInputChange,
     handleInputFocus,
     handleInputKeyDown,
-    handleInputMouseDown,
     handleListScroll,
     handleOptionSelect,
     handleTokenDismiss,
@@ -269,6 +269,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     readOnly,
     rootRef,
     selectedLabels,
+    selectedOptions,
     selectedValues,
     setFloatingRef,
     setItemRef,
@@ -310,25 +311,25 @@ export const Autocomplete = (props: AutocompleteProps) => {
         onMouseDown={handleControlMouseDown}
       >
         <Box className={classes.valueContainer}>
-          {multiple &&
-            visibleSelectedValues.map((selectedValue, index) => {
-              const label = selectedLabels[index] ?? selectedValue;
+          {visibleSelectedValues.map((selectedValue, index) => {
+            const label = selectedLabels[index] ?? selectedValue;
 
-              return (
-                <AutocompleteToken
-                  key={selectedValue}
-                  className={classes.token}
-                  size={chipSize}
-                  label={label}
-                  disabled={disabled || readOnly}
-                  dismissButtonRef={(node) => setTokenRef(index, node)}
-                  onDismiss={() => handleTokenDismiss(selectedValue, label)}
-                  onKeyDown={(event) =>
-                    handleTokenKeyDown(event, index, selectedValue, label)
-                  }
-                />
-              );
-            })}
+            return (
+              <AutocompleteToken
+                key={selectedValue}
+                className={classes.token}
+                size={chipSize}
+                label={label}
+                isNew={selectedOptions[index]?.created}
+                disabled={disabled || readOnly}
+                dismissButtonRef={(node) => setTokenRef(index, node)}
+                onDismiss={() => handleTokenDismiss(selectedValue, label)}
+                onKeyDown={(event) =>
+                  handleTokenKeyDown(event, index, selectedValue, label)
+                }
+              />
+            );
+          })}
 
           {hiddenTagCount > 0 && (
             <Box
@@ -364,13 +365,12 @@ export const Autocomplete = (props: AutocompleteProps) => {
             disabled={disabled}
             readOnly={readOnly}
             placeholder={selectedValues.length === 0 ? placeholder : undefined}
-            value={displayedInputValue}
+            value={currentInputValue}
             className={classes.input}
             onChange={handleInputChange}
             {...(getReferenceProps({
               onFocus: handleInputFocus,
               onKeyDown: handleInputKeyDown,
-              onMouseDown: handleInputMouseDown,
             }) as Record<string, unknown>)}
             autoComplete="off"
           />

--- a/src/components/Autocomplete/AutocompleteListbox.tsx
+++ b/src/components/Autocomplete/AutocompleteListbox.tsx
@@ -107,6 +107,7 @@ export const AutocompleteListbox = (props: AutocompleteListboxProps) => {
                 <Icon
                   name={selected ? 'checkbox-checked' : 'checkbox'}
                   fill={selected ? 'icon' : 'icon.subtlest'}
+                  display="block"
                   aria-hidden
                 />
               ) : undefined

--- a/src/components/Autocomplete/AutocompleteToken.tsx
+++ b/src/components/Autocomplete/AutocompleteToken.tsx
@@ -6,6 +6,7 @@ type AutocompleteTokenProps = {
   className?: string;
   disabled?: boolean;
   dismissButtonRef?: Ref<HTMLButtonElement>;
+  isNew?: boolean;
   label: string;
   onDismiss: () => void;
   onKeyDown: KeyboardEventHandler<HTMLButtonElement>;
@@ -17,6 +18,7 @@ export const AutocompleteToken = (props: AutocompleteTokenProps) => {
     className,
     disabled,
     dismissButtonRef,
+    isNew,
     label,
     onDismiss,
     onKeyDown,
@@ -26,6 +28,7 @@ export const AutocompleteToken = (props: AutocompleteTokenProps) => {
   return (
     <Chip
       className={className}
+      data-new={isNew || undefined}
       size={size}
       dismissable
       disabled={disabled}

--- a/src/components/Autocomplete/types.ts
+++ b/src/components/Autocomplete/types.ts
@@ -56,7 +56,6 @@ export type AutocompleteStateProps<Multiple extends boolean = false> = {
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean, reason: AutocompleteOpenChangeReason) => void;
   multiple?: Multiple;
-  selectedOptionLabel?: string;
   disabled?: boolean;
   readOnly?: boolean;
 };

--- a/src/components/Autocomplete/useAutocompleteController.ts
+++ b/src/components/Autocomplete/useAutocompleteController.ts
@@ -55,7 +55,7 @@ import type {
 const LOAD_MORE_THRESHOLD_PX = 32;
 
 const defaultGetCreateOptionLabel = (inputValue: string) =>
-  `Create “${inputValue}”`;
+  `Add “${inputValue}”`;
 
 const chipSizeByAutocompleteSize = {
   sm: 'sm',
@@ -163,11 +163,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     () => new Map(options.map((option) => [option.value, option])),
     [options],
   );
-  const initialValue = controlledValue ?? defaultValue;
-  const initialSelectedLabel =
-    typeof initialValue === 'string'
-      ? (optionByValue.get(initialValue)?.label ?? initialValue)
-      : '';
   const handleValueChange = useCallback(
     (
       nextValue: AutocompleteValue<boolean>,
@@ -208,16 +203,12 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     defaultValue,
     onValueChange: handleValueChange,
     inputValue: controlledInputValue,
-    defaultInputValue: defaultInputValue ?? initialSelectedLabel,
+    defaultInputValue,
     onInputValueChange: handleInputValueChange,
     open: controlledOpen,
     defaultOpen,
     onOpenChange,
     multiple,
-    selectedOptionLabel:
-      typeof controlledValue === 'string'
-        ? (optionByValue.get(controlledValue)?.label ?? controlledValue)
-        : undefined,
     disabled,
     readOnly,
   });
@@ -228,13 +219,18 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     () => getAutocompleteValueArray(currentValue, Boolean(multiple)),
     [currentValue, multiple],
   );
+  const selectedOptions = useMemo(
+    () =>
+      selectedValues.map((selectedValue) => optionByValue.get(selectedValue)),
+    [optionByValue, selectedValues],
+  );
   const selectedLabels = useMemo(
     () =>
       selectedValues.map(
-        (selectedValue) =>
-          optionByValue.get(selectedValue)?.label ?? selectedValue,
+        (selectedValue, index) =>
+          selectedOptions[index]?.label ?? selectedValue,
       ),
-    [optionByValue, selectedValues],
+    [selectedOptions, selectedValues],
   );
 
   const visibleOptions = useMemo(() => {
@@ -263,7 +259,7 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     };
   }, [allowCustomValue, currentInputValue, getCreateOptionLabel, options]);
   const navigationItems = useMemo(
-    () => (createOption ? [...visibleOptions, createOption] : visibleOptions),
+    () => (createOption ? [createOption, ...visibleOptions] : visibleOptions),
     [createOption, visibleOptions],
   );
   const disabledIndices = useMemo(
@@ -332,15 +328,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
   const visibleTagCount = shouldLimitTags ? limitTags : selectedValues.length;
   const visibleSelectedValues = selectedValues.slice(0, visibleTagCount);
   const hiddenTagCount = selectedValues.length - visibleSelectedValues.length;
-  const selectedSingleLabel =
-    typeof currentValue === 'string'
-      ? (optionByValue.get(currentValue)?.label ?? currentValue)
-      : '';
-  const displayedInputValue =
-    !multiple && typeof currentValue === 'string' && !currentInputValue
-      ? selectedSingleLabel
-      : currentInputValue;
-
   const focusInput = useCallback(() => {
     inputRef.current?.focus();
   }, []);
@@ -438,31 +425,10 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     },
     [state],
   );
-  const handleInputFocus = useCallback(
-    (event: FocusEvent<HTMLInputElement>) => {
-      setFocusedWithin(true);
-      state.openPopup('focus');
-
-      if (!multiple && typeof currentValue === 'string') {
-        event.currentTarget.select();
-      }
-    },
-    [currentValue, multiple, state],
-  );
-  const handleInputMouseDown = useCallback(
-    (event: MouseEvent<HTMLInputElement>) => {
-      if (
-        !multiple &&
-        typeof currentValue === 'string' &&
-        document.activeElement !== event.currentTarget
-      ) {
-        event.preventDefault();
-        event.currentTarget.focus();
-        event.currentTarget.select();
-      }
-    },
-    [currentValue, multiple],
-  );
+  const handleInputFocus = useCallback(() => {
+    setFocusedWithin(true);
+    state.openPopup('focus');
+  }, [state]);
   const handleInputKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
       if (disabled || readOnly) {
@@ -495,7 +461,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
       if (
         (event.key === 'Backspace' || event.key === 'Delete') &&
         currentInputValue.length === 0 &&
-        multiple &&
         visibleSelectedValues.length > 0
       ) {
         event.preventDefault();
@@ -506,7 +471,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
       if (
         event.key === 'ArrowLeft' &&
         currentInputValue.length === 0 &&
-        multiple &&
         visibleSelectedValues.length > 0
       ) {
         event.preventDefault();
@@ -519,7 +483,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
       focusToken,
       handleOptionSelect,
       isOpen,
-      multiple,
       navigationItems,
       readOnly,
       resolvedActiveIndex,
@@ -618,7 +581,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     currentValue,
     density,
     disabled,
-    displayedInputValue,
     error,
     floating,
     getFloatingProps,
@@ -630,7 +592,6 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     handleInputChange,
     handleInputFocus,
     handleInputKeyDown,
-    handleInputMouseDown,
     handleListScroll,
     handleOptionSelect,
     handleTokenDismiss,
@@ -653,6 +614,7 @@ export const useAutocompleteController = (props: AutocompleteProps) => {
     readOnly,
     rootRef,
     selectedLabels,
+    selectedOptions,
     selectedValues,
     setFloatingRef,
     setItemRef,

--- a/src/components/Autocomplete/useAutocompleteState.ts
+++ b/src/components/Autocomplete/useAutocompleteState.ts
@@ -26,7 +26,6 @@ export const useAutocompleteState = <Multiple extends boolean = false>({
   defaultOpen = false,
   onOpenChange,
   multiple = false as Multiple,
-  selectedOptionLabel,
   disabled = false,
   readOnly = false,
 }: AutocompleteStateProps<Multiple>) => {
@@ -92,11 +91,7 @@ export const useAutocompleteState = <Multiple extends boolean = false>({
 
       commitInputValue(nextValue, 'input');
 
-      if (
-        !multiple &&
-        typeof value === 'string' &&
-        nextValue !== selectedOptionLabel
-      ) {
+      if (!multiple && typeof value === 'string') {
         commitValue(null as AutocompleteValue<Multiple>, 'clear');
       }
 
@@ -108,7 +103,6 @@ export const useAutocompleteState = <Multiple extends boolean = false>({
       commitValue,
       isInteractionBlocked,
       multiple,
-      selectedOptionLabel,
       value,
     ],
   );
@@ -146,7 +140,7 @@ export const useAutocompleteState = <Multiple extends boolean = false>({
       }
 
       commitValue(option.value as AutocompleteValue<Multiple>, reason);
-      commitInputValue(option.label, 'selection');
+      commitInputValue('', 'selection');
       commitOpen(false, 'selection');
     },
     [

--- a/src/recipes/autocomplete.ts
+++ b/src/recipes/autocomplete.ts
@@ -121,6 +121,12 @@ const autocompleteBase = {
     minWidth: '0',
     maxWidth: 'full',
     flex: '0 1 auto',
+    _new: {
+      bg: 'transparent',
+      outlineWidth: '1',
+      outlineStyle: 'dashed',
+      outlineColor: 'border.warning',
+    },
   },
   overflowIndicator: {
     display: 'inline-flex',

--- a/src/recipes/chip.ts
+++ b/src/recipes/chip.ts
@@ -134,6 +134,7 @@ export const chipRecipe = defineSlotRecipe({
       position: 'relative',
       display: 'inline-flex',
       alignItems: 'center',
+      justifyContent: 'center',
       minW: '0',
       flexShrink: '0',
       bg: 'transparent',

--- a/src/storybook/docs/conditions.mdx
+++ b/src/storybook/docs/conditions.mdx
@@ -898,6 +898,7 @@ compoundVariants: [
     ['_closed',       '&:is([closed], [data-closed=true], [data-state="closed"])'],
     ['_selected',     '&:is([aria-selected=true], [data-selected=true])'],
     ['_highlighted',  '&[data-highlighted=true]'],
+    ['_new',          '&[data-new=true]'],
     ['_dragging',     '&[data-dragging=true]'],
     ['_loading',      '&:is([data-loading=true], [aria-busy=true])'],
     ['_hidden',       '&:is([hidden], [data-hidden=true])'],

--- a/src/styles/utilities/conditions.ts
+++ b/src/styles/utilities/conditions.ts
@@ -21,6 +21,7 @@ export const conditions = {
   collapsed:
     '&:is([aria-collapsed=true], [data-collapsed=true], [data-state="collapsed"])',
   highlighted: '&[data-highlighted=true]',
+  new: '&[data-new=true]',
   complete: '&[data-complete=true]',
   incomplete: '&[data-incomplete=true]',
   dragging: '&[data-dragging=true]',


### PR DESCRIPTION
## Summary

- render single-select Autocomplete selections as dismissible chips, matching multi-select behavior
- style newly added custom values through the global _new condition and improve Add-option ordering and matching behavior
- add single- and multi-select Autocomplete Playroom snippets
- fix custom-option row spacing and center Chip dismiss icons

## Validation

- npm run validate:full
- React Doctor: 100/100
- visually verified Autocomplete row spacing and standalone Chip dismiss-button alignment in Storybook