### PR TITLE
feat(minor): release add rowId prop to ListItem

### DIFF
--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -21,6 +21,11 @@ const items = [
   },
   { id: 'integrations', label: 'Integrations', desc: 'Connect external tools' },
 ];
+const records = [
+  { id: '10482', orderNumber: 'WO-2201', customer: 'Northwind Traders' },
+  { id: '10517', orderNumber: 'WO-2202', customer: 'Contoso Manufacturing' },
+  { id: '10688', orderNumber: 'WO-2203', customer: 'Fabrikam Industrial' },
+];
 const repeatedItems = ['first', 'second'].flatMap((copy) =>
   items.map((item) => ({ ...item, instanceId: `${copy}-${item.id}` })),
 );
@@ -356,5 +361,25 @@ export const ExFloatingSearchBar: Story = {
   name: 'Ex: Floating search bar',
   args: {},
   render: () => <FloatingSearchBarExample />,
+  parameters: { controls: { disable: true } },
+};
+
+export const RowIdentity: Story = {
+  name: 'Row identity',
+  args: {},
+  render: () => (
+    <Card variant="flat" minW="2xs">
+      <List role="listbox" aria-label="Work orders">
+        {records.map((record) => (
+          <ListItem
+            key={record.id}
+            rowId={record.id}
+            label={record.orderNumber}
+            description={record.customer}
+          />
+        ))}
+      </List>
+    </Card>
+  ),
   parameters: { controls: { disable: true } },
 };

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -80,6 +80,16 @@ export type ListItemProps = Omit<
     iconBeforeFill?: IconProps['fill'];
     /** Fill token for `iconAfter`. */
     iconAfterFill?: IconProps['fill'];
+    /**
+     * Internal record primary key rendered as `data-row-id` on the item root.
+     * It targets one row in a test and identifies which record an interaction
+     * applied to.
+     *
+     * It must never be a row index, a composite value, or a customer-facing
+     * identifier such as an order number or part number. It is unrelated to
+     * React's `key`.
+     */
+    rowId?: string;
   };
 
 /**
@@ -115,6 +125,7 @@ export const ListItem = (props: ListItemProps) => {
     iconBeforeFill,
     iconAfterFill,
     href,
+    rowId,
     ...rest
   } = props;
   const [className, otherProps] = splitProps(rest);
@@ -161,6 +172,7 @@ export const ListItem = (props: ListItemProps) => {
       role="option"
       aria-selected={isSelected}
       data-selected={isSelected || undefined}
+      data-row-id={rowId}
       {...otherProps}
     >
       {hasCustomChildren ? (


### PR DESCRIPTION
Item 1 of the row-identity work (Track A, step 4).

Adds a typed `rowId` prop to `ListItem` that renders `data-row-id` on the item root, so a test can target one row and the behavior log can identify which record an interaction applied to.

## What changed

- `ListItemProps` gains `rowId?: string`, documented as an internal record primary key — never a row index, a composite value, or a customer-facing identifier such as an order number or part number, and unrelated to React's `key`.
- `rowId` is destructured out of props, so it never reaches the rest spread.
- `data-row-id={rowId}` is placed **before** `{...otherProps}` on the root, so a consumer who passes `data-row-id` directly still wins. The existing rest-spread passthrough keeps working unchanged.
- An undefined `rowId` renders no attribute at all.
- `List.stories.tsx` gains a `RowIdentity` story whose fixture gives each record an internal `id` (`10482`) distinct from the displayed `orderNumber` (`WO-2201`), to demonstrate why the primary key and the business identifier are not interchangeable.

## Why the prop, when rest-spread already worked

`ListItem` already forwards unknown props to its root, so `data-row-id="123"` reached the DOM before this change. That contract was accidental. A declared prop is discoverable, documented, greppable and lintable — the companion ESLint checks in Cetec-ERP #21329 depend on the value being an expression that resolves to a primary key.

## Verification

`npm run prepare`, `npm run lint`, `npm run typecheck`, `npm run build` and `npm run check:jsdoc` all pass.

No unit tests: this repo has no component test infrastructure (no `test` script, no vitest/jest/testing-library dependency, no `*.test.*` files under `src`). The three behaviors above are guaranteed structurally by the JSX ordering but are unverified at runtime. Worth addressing separately — Track D depends on this library's testability.

## Note

The `variant="divider"` branch early-returns a different root that receives neither `otherProps` nor `data-row-id`, so a divider silently drops a `rowId`. That matches the documented behavior for dividers, and dividers are not records, so it is left as-is.

## Related

- Cetec-ERP #21329 — `cetec/valid-track-attrs` row-id checks (Item 4)
- Still open: Item 2, which stops the app `Table` emitting positional row ids, and Item 3, the `getRowId` backfill

https://claude.ai/code/session_01GvPmsABpBBHyUNMxbUTapi