### PR TITLE
feat(minor): stamp data-track-object on portal roots

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -407,7 +407,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
 
       {isOpen && !disabled && !readOnly && (
         <FloatingPortal>
-          <DsChainPortalRoot>
+          <DsChainPortalRoot reference={floating.elements.domReference}>
             <FloatingFocusManager
               context={floating.context}
               modal={false}

--- a/src/components/DsChainScope/DsChainPortalRoot.tsx
+++ b/src/components/DsChainScope/DsChainPortalRoot.tsx
@@ -1,14 +1,26 @@
 import type { ReactNode } from 'react';
 
-import { dsChainValue, useDsChain } from '~/utils/dsChain';
+import { dsChainValue, dsObjectValue, useDsChain } from '~/utils/dsChain';
 
 type DsChainPortalRootProps = {
   /** Portal contents that need DOM ancestry back to the opening subtree. */
   children?: ReactNode;
+  /**
+   * The element that opened this portal — Floating UI's `elements.domReference`
+   * at the call site. Its nearest `data-track-object` ancestor is copied onto
+   * the portal root, giving portaled content the business-object identity that
+   * DOM ancestry cannot supply.
+   *
+   * Optional because not every portal has one. A `Modal` driven by an `open`
+   * prop never sets a reference, and omitting it there yields no object rather
+   * than a guessed one.
+   */
+  reference?: Element | null;
 };
 
 /**
- * Wraps portal contents in an element stamped with the resolved chain.
+ * Wraps portal contents in an element stamped with the resolved chain and the
+ * business object the interaction belongs to.
  *
  * Internal. Render it as the outermost child of a `FloatingPortal` so the
  * chain is read at the portal's position in the React tree, which is where the
@@ -16,25 +28,40 @@ type DsChainPortalRootProps = {
  * position. Reading it in the component body instead would miss any scope the
  * component's own root `Box` opened for its subtree.
  *
- * The attribute is written during render, never from an effect: portal content
- * mounts late, and an effect-stamped attribute can lose the race against a
- * click that lands immediately after paint.
+ * The two identities arrive by different routes and that is deliberate. The
+ * chain follows the React tree, because a portal's contents are still React
+ * descendants of what opened them. The object follows the DOM from the
+ * reference element, because the application authors it as markup — a layout
+ * wrapper on a legacy Perl screen, individual elements on a React screen — and
+ * never through React context.
+ *
+ * The attributes are written during render, never from an effect: portal
+ * content mounts late, and an effect-stamped attribute can lose the race
+ * against a click that lands immediately after paint.
  *
  * The wrapper is an unstyled, statically positioned `div`. Every floating
  * element it wraps is absolutely or fixed positioned, so it stays out of flow
  * and the wrapper contributes no layout box of its own.
  */
-export const DsChainPortalRoot = ({ children }: DsChainPortalRootProps) => {
+export const DsChainPortalRoot = ({
+  children,
+  reference,
+}: DsChainPortalRootProps) => {
   const chain = useDsChain();
 
   return (
-    // The marker is unconditional; the chain value is not. An empty chain emits
-    // no `data-ds-chain`, so without the marker an untagged portal is
+    // The marker is unconditional; neither value is. An empty chain emits no
+    // `data-ds-chain`, so without the marker an untagged portal is
     // indistinguishable from an ordinary element and a consumer walking up the
     // DOM continues past it into `document.body` — producing a chain from
     // whatever it finds there, with no error. The marker makes "portal
-    // boundary, chain resolved to nothing" a state a reader can detect.
-    <div data-ds-portal-root="" data-ds-chain={dsChainValue(chain)}>
+    // boundary, resolved to nothing" a state a reader can detect, and it is
+    // what tells that reader to stop and take both values from here.
+    <div
+      data-ds-portal-root=""
+      data-ds-chain={dsChainValue(chain)}
+      data-track-object={dsObjectValue(reference)}
+    >
       {children}
     </div>
   );

--- a/src/components/DsChainScope/DsChainScope.stories.tsx
+++ b/src/components/DsChainScope/DsChainScope.stories.tsx
@@ -308,3 +308,132 @@ export const NestedPortalsCompose: Story = {
   },
   parameters: { controls: { disable: true } },
 };
+
+const openStatusListbox = async (canvasElement: HTMLElement) => {
+  const trigger = within(canvasElement).getByRole('combobox', {
+    name: /status/i,
+  });
+
+  trigger.focus();
+  await userEvent.keyboard('{ArrowDown}');
+
+  const listbox = await within(canvasElement.ownerDocument.body).findByRole(
+    'listbox',
+  );
+
+  return listbox.closest('[data-ds-portal-root]');
+};
+
+export const PortalCarriesTheObject: Story = {
+  name: 'Ex: Portaled Listbox Carries The Object',
+  render: () => (
+    // The shape of a legacy Perl screen: one layout wrapper carries the object
+    // for the whole page, and every interaction on it resolves to that object.
+    <Box data-track-object="orderline">
+      <Box data-testid="page">
+        <Select aria-label="Status" placeholder="Choose a status...">
+          <SelectOption value="draft" label="Draft" />
+          <SelectOption value="published" label="Published" />
+        </Select>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const portalRoot = await openStatusListbox(canvasElement);
+
+    // The wrapper that carries the object is not an ancestor of the portal —
+    // that is the whole bug. Walking up from inside the listbox reaches
+    // `document.body` and stops.
+    expect(portalRoot?.closest('[data-track-object]')).toBe(portalRoot);
+
+    // The value is copied from the opening element's nearest tagged ancestor.
+    expect(portalRoot).toHaveAttribute('data-track-object', 'orderline');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const NearestObjectWins: Story = {
+  name: 'Ex: Nearest Object Wins',
+  render: () => (
+    // The shape of a React screen: several tagged regions on one page, so an
+    // interaction has to resolve to the region it started in, not to the page.
+    <Box data-track-object="order">
+      <Box data-track-object="orderline">
+        <Select aria-label="Status" placeholder="Choose a status...">
+          <SelectOption value="draft" label="Draft" />
+          <SelectOption value="published" label="Published" />
+        </Select>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const portalRoot = await openStatusListbox(canvasElement);
+
+    expect(portalRoot).toHaveAttribute('data-track-object', 'orderline');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+export const UntaggedPageYieldsNoObject: Story = {
+  name: 'Ex: Untagged Page Yields No Object',
+  render: () => (
+    // No ancestor carries an object, which is the state of every screen the
+    // application has not tagged yet.
+    <Box>
+      <Select aria-label="Status" placeholder="Choose a status...">
+        <SelectOption value="draft" label="Draft" />
+        <SelectOption value="published" label="Published" />
+      </Select>
+    </Box>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const portalRoot = await openStatusListbox(canvasElement);
+
+    // The boundary is still findable, so a reader stops here and records the
+    // object as unknown rather than walking on and borrowing one.
+    expect(portalRoot).not.toBeNull();
+    expect(portalRoot).not.toHaveAttribute('data-track-object');
+  },
+  parameters: { controls: { disable: true } },
+};
+
+const ModalWithoutAnOpenerExample = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box data-track-object="orderline">
+      <Button onClick={() => setOpen(true)}>Open modal</Button>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalHeader>Assign owner</ModalHeader>
+        <ModalBody>
+          <Text>Nothing here resolves to an object.</Text>
+        </ModalBody>
+      </Modal>
+    </Box>
+  );
+};
+
+export const ModalHasNoOpeningElement: Story = {
+  name: 'Ex: Modal Resolves No Object',
+  render: () => <ModalWithoutAnOpenerExample />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: /open modal/i }));
+
+    const portalRoot = (await screen.findByText('Assign owner')).closest(
+      '[data-ds-portal-root]',
+    );
+
+    // A Modal is driven by the `open` prop and never sets a reference, so
+    // there is no opening element to resolve from. The chain still arrives
+    // through React context; the object does not, and no object is emitted.
+    // This is the known gap, recorded here rather than papered over: a guessed
+    // page-level object would be right on a legacy screen and wrong on a React
+    // screen that tags individual elements.
+    expect(portalRoot).not.toBeNull();
+    expect(portalRoot).not.toHaveAttribute('data-track-object');
+  },
+  parameters: { controls: { disable: true } },
+};

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -670,7 +670,7 @@ export const Menu = (props: MenuProps) => {
         )}
         {isOpen && (
           <FloatingPortal>
-            <DsChainPortalRoot>
+            <DsChainPortalRoot reference={floating.elements.domReference}>
               <FloatingFocusManager
                 context={floating.context}
                 modal={false}

--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -590,7 +590,7 @@ export const SubMenu = (props: SubMenuProps) => {
 
       {open && (
         <FloatingPortal>
-          <DsChainPortalRoot>
+          <DsChainPortalRoot reference={floating.elements.domReference}>
             <FloatingFocusManager
               context={floating.context}
               modal={false}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -182,6 +182,14 @@ export const Modal = (props: ModalProps) => {
   return (
     <ModalContext.Provider value={contextValue}>
       <FloatingPortal>
+        {/*
+         * No `reference`: a Modal is driven by the `open` prop and never calls
+         * `refs.setReference`, so there is no opening element to resolve a
+         * business object from. Clicks inside resolve their chain but no
+         * object, which is the correct answer here — inventing one from the
+         * page would be right on a legacy screen and wrong on a React screen
+         * that tags individual elements.
+         */}
         <DsChainPortalRoot>
           <Box className={classes.positionWrapper}>
             <FloatingOverlay

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -545,7 +545,7 @@ export const Select = (props: SelectProps) => {
 
       {isOpen && !disabled && (
         <FloatingPortal>
-          <DsChainPortalRoot>
+          <DsChainPortalRoot reference={floating.elements.domReference}>
             <FloatingFocusManager
               context={floating.context}
               modal={false}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -94,7 +94,7 @@ export const Tooltip = (props: TooltipProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const arrowRef = useRef<SVGSVGElement>(null);
 
-  const { refs, floatingStyles, context } = useOverlayFloating({
+  const { refs, elements, floatingStyles, context } = useOverlayFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
     placement,
@@ -135,7 +135,7 @@ export const Tooltip = (props: TooltipProps) => {
 
       {isOpen && (
         <FloatingPortal>
-          <DsChainPortalRoot>
+          <DsChainPortalRoot reference={elements.domReference}>
             <Box
               {...dsComponent('Tooltip')}
               ref={refs.setFloating}

--- a/src/utils/dsChain.ts
+++ b/src/utils/dsChain.ts
@@ -25,6 +25,14 @@ export const DS_PORTAL_ROOT_ATTRIBUTE = 'data-ds-portal-root';
  */
 export const DS_CHAIN_MAX_DEPTH = 5;
 
+/**
+ * Attribute carrying business-object identity. The application authors it — on
+ * a layout wrapper for legacy Perl screens, on individual elements on React
+ * screens. The design system never invents a value; it only copies one onto a
+ * portal root, which is the single place DOM ancestry cannot supply it.
+ */
+export const DS_OBJECT_ATTRIBUTE = 'data-track-object';
+
 // Module-level constant so every reader outside a scope shares one identity.
 // A fresh `[]` default would hand consumers a new value on each render and
 // defeat the memoization in the provider.
@@ -81,3 +89,25 @@ export const extendDsChain = (
  */
 export const dsChainValue = (chain: readonly string[]): string | undefined =>
   chain.length > 0 ? chain.join(DS_CHAIN_SEPARATOR) : undefined;
+
+/**
+ * Resolves the business object governing `element` by walking up the DOM to the
+ * nearest ancestor carrying `DS_OBJECT_ATTRIBUTE`, `element` itself included.
+ *
+ * Nearest wins. A legacy Perl screen tags one layout wrapper, so every element
+ * on it resolves to the same object; a React screen tags individual elements,
+ * so an interaction resolves to the region it started in rather than to the
+ * page. Both fall out of the same walk.
+ *
+ * Returns `undefined` when no ancestor is tagged — including for an element
+ * that is not in the document, and for an empty attribute value — so React
+ * omits the attribute instead of emitting an empty string that a consumer would
+ * have to special-case. An untagged screen must produce no answer, never a
+ * borrowed one.
+ */
+export const dsObjectValue = (
+  element: Element | null | undefined,
+): string | undefined =>
+  element
+    ?.closest(`[${DS_OBJECT_ATTRIBUTE}]`)
+    ?.getAttribute(DS_OBJECT_ATTRIBUTE) || undefined;


### PR DESCRIPTION
Closes the object-name half of the portal problem that [#184](https://github.com/Cetec-ERP/Cetec-Design-System/pull/184) deferred.

## The problem

A portaled overlay mounts at `document.body`, which makes it a **sibling** of the element the application tags with the business object, not a descendant. Walking up from inside a menu, listbox or tooltip reaches `<body>` and stops. On a legacy Perl screen that means the object is never found; on a React screen, where `data-track-object` sits on individual elements, a walk-up that continues past the portal borrows whatever it lands on. Both failures are silent.

#184 solved this for the interaction chain by carrying it through React context. It could not solve it for the object, because the object is authored as markup rather than through React — a layout wrapper on legacy screens, individual elements on React screens.

## What this does

`DsChainPortalRoot` now takes the element that opened the portal and copies the value of that element's nearest `data-track-object` ancestor onto the portal root, alongside the chain it already stamps.

- `DS_OBJECT_ATTRIBUTE` and `dsObjectValue()` in `src/utils/dsChain.ts`. The walk is inclusive of the element itself and returns `undefined` when nothing is tagged, so React omits the attribute rather than emitting an empty string.
- **Nearest wins.** A legacy screen tagged on one layout wrapper and a React screen tagged on individual elements both resolve correctly from the same walk. A page with several tagged regions resolves to the region the interaction started in.
- Written **during render, never from an effect** — the same race `#184` already guards: portal content mounts late, and an effect-stamped attribute can lose to a click that lands immediately after paint.
- Five call sites pass `floating.elements.domReference`: `Autocomplete`, `Menu`, `SubMenu`, `Select`, `Tooltip`. That is the reactive element rather than `refs.domReference.current`, so nothing reads a ref during render. `Menu` was already using it.

**The collector rule is unchanged.** Stop at `data-ds-portal-root`; read `data-ds-chain` and now `data-track-object` from there. Never continue past a portal root.

## Modal passes no reference

`Modal` is driven by the `open` prop and never calls `refs.setReference`, so there is no opening element to resolve from. It emits **no object** rather than falling back to a page-level value — that fallback would be right on a legacy screen and wrong on a React screen that tags individual elements, which is exactly the silent-wrong-answer this work exists to prevent.

This is a real gap, not an oversight, and it is recorded as a passing story rather than only a code comment. If we later want object identity inside a `Modal`, the honest fix is to give `Modal` a reference or carry the object through context — not to guess here.

## Verification

Run in a real browser, not just asserted. Four new play stories in `DsChainScope.stories.tsx` cover the legacy shape, nearest-wins, an untagged page, and the `Modal` gap. Beyond those, all six portal components were exercised manually:

| Component | Resolved |
| --- | --- |
| `Select` | nearest tagged ancestor |
| `Menu` | nearest tagged ancestor — opened from **inside a Modal**, resolved the field it sits in rather than the differently-tagged page |
| `SubMenu` | nearest tagged ancestor, on both the menu and submenu roots |
| `Autocomplete` | nearest tagged ancestor |
| `Tooltip` | nearest tagged ancestor |
| `Modal` | nothing, as designed |

The Menu-inside-Modal case is the load-bearing one: nearest-wins held through a portal-in-portal with two competing tagged ancestors.

The three pre-existing portal stories from #184 still pass, so the chain work is unregressed. `lint`, `typecheck`, `check:jsdoc:strict` and `build` all exit 0.

## Context

Decided in the [Front-End Instrumentation brief](https://docs.google.com/document/d/1GuO5RymGbd8VNV5Rgb31xa2dE96zzxKPpD3H8CX4yew/edit), 2026-08-21, as option 2 of three. Option 1 — pointing the overlays at `.body-wrapper` — is cheaper than the brief assumed (that wrapper carries one `min-height` rule inside a `max-width:600px` media query and nothing else, so no containing block and no clipping context) but it only fixes legacy screens, and the 23 `only_main_content` templates have no `.body-wrapper` at all.

https://claude.ai/code/session_01LsW7ndGCBL1iKDiy8TdsoQ
